### PR TITLE
Add export for rollagen

### DIFF
--- a/src/export/meetbouten/config.py
+++ b/src/export/meetbouten/config.py
@@ -47,3 +47,16 @@ class ReferentiepuntenExportConfig:
     format = 'referentiepuntid:num|geometrie:xco|geometrie:yco|' \
              'hoogte_tov_nap:num|datum:dat|locatie:str|geometrie:geo'
     path = '/gob/meetbouten/referentiepunten/'
+
+
+class RollagenExportConfig:
+    """
+    Example:
+        rollaagid: AK25:
+        http://localhost:5000/gob/meetbouten/rollagen/AK25/
+        =>
+        $$AK25$$|1|121287|485235|POINT (121287.0 485245.0)
+
+    """
+    format = 'rollaagid:str|$idx:num|geometrie:xco|geometrie:yco|geometrie:geo'
+    path = '/gob/meetbouten/rollagen/?order_by=rollaagid'

--- a/src/tests/meetbouten/test_meetbout.py
+++ b/src/tests/meetbouten/test_meetbout.py
@@ -30,6 +30,13 @@ def test_export_entity(monkeypatch):
     }
     assert(_export_entity(meetbout, config.format) == "$$1$$|$$$$|||||$$$$|||$$N$$|$$$$|$$$$|$$$$||$$$$|$$$$||")
 
+    config = CONFIG_MAPPING['rollagen']
+    rollaag = {
+        'rollaagid': 'AA01',
+        'x': 'y'
+    }
+    assert(_export_entity(rollaag, config.format, 1) == "$$AA01$$|1|||")
+
 
 class MockAPI:
     def __init__(self, host=None, path=None):


### PR DESCRIPTION
Rollagen uses the order_by parameter in the API and an index counter. The variable $idx was added to be used as a counter in the export file.