### PR TITLE
Keep docker alive for acceptance

### DIFF
--- a/src/export/__main__.py
+++ b/src/export/__main__.py
@@ -6,6 +6,7 @@ This module contains the export entries for the meetbouten catalog
 import os
 from pathlib import Path
 import tempfile
+import time
 
 from export.config import get_host, get_args
 from export.connector.objectstore import connect_to_objectstore
@@ -56,7 +57,7 @@ def export_collection(host, catalog, collection, file_name):
     # Distribute to final location
     with open(temporary_file, 'rb') as fp:
         distribute_to_objectstore(connection,
-                                  collection,
+                                  catalog,
                                   file_name,
                                   fp,
                                   'text/plain')
@@ -68,4 +69,13 @@ def export_collection(host, catalog, collection, file_name):
 host = get_host()
 args = get_args()
 
-export_collection(host=host, catalog=args.catalog, collection=args.collection, file_name=args.file_name)
+keep_alive = True
+
+if args.catalog:
+    # If we receive a catalog as an argument, start exporting
+    export_collection(host=host, catalog=args.catalog, collection=args.collection, file_name=args.file_name)
+else:
+    # Run indefinite to have a docker container available for exports
+    while keep_alive:
+        print('.')
+        time.sleep(60)

--- a/src/export/config.py
+++ b/src/export/config.py
@@ -32,10 +32,10 @@ def get_args():
     :return: A dictionary containing the collection and file names
     """
     parser = argparse.ArgumentParser(description='Export data collection')
-    parser.add_argument('catalog', type=str,
+    parser.add_argument('catalog', type=str, nargs='?',
                         help='the name of the data catalog (example: "meetbouten"')
-    parser.add_argument('collection', type=str,
+    parser.add_argument('collection', type=str, nargs='?',
                         help='the name of the data collection (example: "meetbouten"')
-    parser.add_argument('file_name', type=str,
+    parser.add_argument('file_name', type=str, nargs='?',
                         help='the name of the file to write the output to (example: "/tmp/MBT_MEETBOUT.dat")')
     return parser.parse_args()

--- a/src/tests/test_main.py
+++ b/src/tests/test_main.py
@@ -1,7 +1,9 @@
 import importlib
 import os
 import pytest
+import time
 
+import export
 import export.config
 import export.meetbouten
 import export.connector.objectstore
@@ -54,6 +56,10 @@ def export_entity(c, h, f):
     file_name = f
 
 
+def mock_sleep(t):
+    export.__main__.keep_alive = False
+
+
 def test_main(monkeypatch):
     monkeypatch.setitem(__builtins__, 'open', mock_open)
     monkeypatch.setattr(export.config, 'get_host', lambda: 'host')
@@ -68,7 +74,16 @@ def test_main(monkeypatch):
     assert(host == 'host')
     assert(file_name == temporary_file)
 
-    monkeypatch.setattr(export.config, 'get_args', lambda: MockArgs('unknow', 'unknown', 'file_name'))
+    monkeypatch.setattr(export.config, 'get_args', lambda: MockArgs('unknown', 'unknown', 'file_name'))
 
     with pytest.raises(KeyError):
         importlib.reload(export.__main__)
+
+def test_main_without_args(monkeypatch):
+    monkeypatch.setattr(export.config, 'get_host', lambda: 'host')
+    monkeypatch.setattr(export.config, 'get_args', lambda: MockArgs(None, None, None))
+    monkeypatch.setattr(time, 'sleep', mock_sleep)
+
+    importlib.reload(export.__main__)
+
+    from export import __main__


### PR DESCRIPTION
The docker container will now keep running to allow exports to be executed on the container with the correct environment variables. Also a small fix to distribute the file to a catalog folder instead of a collection folder on objectstore. The keep_alive variable was added to be able to unit test the while loop.