### PR TITLE
Change the order of columns in csv export

### DIFF
--- a/src/gobexport/exporter/config/gebieden.py
+++ b/src/gobexport/exporter/config/gebieden.py
@@ -40,8 +40,8 @@ class StadsdelenExportConfig:
             'mime_type': 'application/octet-stream',
             'format': {
                 'identificatie': 'id',
-                'naam': 'naam',
                 'code': 'code',
+                'naam': 'naam',
                 'datumBeginGeldigheid': 'begindatum',
                 'datumEindeGeldigheid': 'einddatum',
                 'documentdatum': 'docdatum',
@@ -69,6 +69,10 @@ class StadsdelenExportConfig:
             'endpoint': '/gob/toestanden/?collections=gebieden:stadsdelen',
             'filename': 'ActueelEnHistorie_CSV/GBD_stadsdeel.csv',
             'mime_type': 'plain/text',
+            'format': 'identificatie,volgnummer,registratiedatum,code,naam,' \
+                      'datumBeginGeldigheid,datumEindeGeldigheid,documentdatum,' \
+                      'documentnummer,datumBeginTijdvak,datumEindeTijdvak,' \
+                      'geometrie'
         }
     }
 
@@ -89,18 +93,19 @@ class WijkenExportConfig:
             'mime_type': 'application/octet-stream',
             'format': {
                 'identificatie': 'id',
-                'naam': 'naam',
                 'code': 'code',
+                'naam': 'naam',
                 'datumBeginGeldigheid': 'begindatum',
                 'datumEindeGeldigheid': 'einddatum',
                 'documentdatum': 'docdatum',
                 'documentnummer': 'docnummer',
+                'cbsCode': 'CBS_code',
                 'ggwIdentificatie': 'ggw_id',
-                'ggwNaam': 'ggw_naam',
                 'ggwCode': 'ggw_code',
+                'ggwNaam': 'ggw_naam',
                 'stadsdeelidentificatie': 'sdl_id',
-                'stadsdeelnaam': 'sdl_naam',
                 'stadsdeelcode': 'sdl_code',
+                'stadsdeelnaam': 'sdl_naam',
                 'brkGemeenteidentificatie': 'gme_id',
                 'brkGemeentenaam': 'gme_naam',
             },
@@ -124,6 +129,11 @@ class WijkenExportConfig:
             'endpoint': '/gob/toestanden/?collections=gebieden:wijken,gebieden:stadsdelen',
             'filename': 'ActueelEnHistorie_CSV/GBD_wijk.csv',
             'mime_type': 'plain/text',
+            'format': 'identificatie,volgnummer,registratiedatum,code,naam,' \
+                      'datumBeginGeldigheid,datumEindeGeldigheid,documentdatum,' \
+                      'documentnummer,cbsCode,datumBeginTijdvak,datumEindeTijdvak,' \
+                      'gebieden:stadsdelenVolgnummer,gebieden:stadsdelenIdentificatie,' \
+                      'gebieden:stadsdelenCode,gebieden:stadsdelenNaam,geometrie'
         }
     }
 
@@ -144,21 +154,22 @@ class BuurtenExportConfig:
             'mime_type': 'application/octet-stream',
             'format': {
                 'identificatie': 'id',
-                'naam': 'naam',
                 'code': 'code',
+                'naam': 'naam',
                 'datumBeginGeldigheid': 'begindatum',
                 'datumEindeGeldigheid': 'einddatum',
                 'documentdatum': 'docdatum',
                 'documentnummer': 'docnummer',
+                'cbsCode': 'CBS_code',
                 'wijkidentificatie': 'wijk_id',
-                'wijknaam': 'wijk_naam',
                 'wijkcode': 'wijk_code',
+                'wijknaam': 'wijk_naam',
                 'ggwIdentificatie': 'ggw_id',
-                'ggwNaam': 'ggw_naam',
                 'ggwCode': 'ggw_code',
+                'ggwNaam': 'ggw_naam',
                 'stadsdeelidentificatie': 'sdl_id',
-                'stadsdeelnaam': 'sdl_naam',
                 'stadsdeelcode': 'sdl_code',
+                'stadsdeelnaam': 'sdl_naam',
                 'brkGemeenteidentificatie': 'gme_id',
                 'brkGemeentenaam': 'gme_naam',
             },
@@ -182,6 +193,13 @@ class BuurtenExportConfig:
             'endpoint': '/gob/toestanden/?collections=gebieden:buurten,gebieden:wijken,gebieden:stadsdelen',
             'filename': 'ActueelEnHistorie_CSV/GBD_buurt.csv',
             'mime_type': 'plain/text',
+            'format': 'identificatie,volgnummer,registratiedatum,code,naam,' \
+                      'datumBeginGeldigheid,datumEindeGeldigheid,documentdatum,' \
+                      'documentnummer,cbsCode,datumBeginTijdvak,datumEindeTijdvak,' \
+                      'gebieden:wijkenVolgnummer,gebieden:wijkenIdentificatie,' \
+                      'gebieden:wijkenCode,gebieden:wijkenNaam,' \
+                      'gebieden:stadsdelenVolgnummer,gebieden:stadsdelenIdentificatie,' \
+                      'gebieden:stadsdelenCode,gebieden:stadsdelenNaam,geometrie'
         }
     }
 
@@ -206,20 +224,20 @@ class BouwblokkenExportConfig:
                 'datumBeginGeldigheid': 'begindatum',
                 'datumEindeGeldigheid': 'einddatum',
                 'buurtidentificatie': 'brt_id',
-                'buurtnaam': 'brt_naam',
                 'buurtcode': 'brt_code',
+                'buurtnaam': 'brt_naam',
                 'wijkidentificatie': 'wijk_id',
-                'wijknaam': 'wijk_naam',
                 'wijkcode': 'wijk_code',
+                'wijknaam': 'wijk_naam',
                 'ggwIdentificatie': 'ggw_id',
-                'ggwNaam': 'ggw_naam',
                 'ggwCode': 'ggw_code',
+                'ggwNaam': 'ggw_naam',
                 'ggpIdentificatie': 'ggp_id',
-                'ggpNaam': 'ggp_naam',
                 'ggpCode': 'ggp_code',
+                'ggpNaam': 'ggp_naam',
                 'stadsdeelidentificatie': 'sdl_id',
-                'stadsdeelnaam': 'sdl_naam',
                 'stadsdeelcode': 'sdl_code',
+                'stadsdeelnaam': 'sdl_naam',
                 'brkGemeenteidentificatie': 'gme_id',
                 'brkGemeentenaam': 'gme_naam',
             },
@@ -244,5 +262,14 @@ class BouwblokkenExportConfig:
                         'gebieden:buurten,gebieden:wijken,gebieden:stadsdelen',
             'filename': 'ActueelEnHistorie_CSV/GBD_bouwblok.csv',
             'mime_type': 'plain/text',
+            'format': 'identificatie,volgnummer,registratiedatum,code,naam,' \
+                      'datumBeginGeldigheid,datumEindeGeldigheid,documentdatum,' \
+                      'documentnummer,cbsCode,datumBeginTijdvak,datumEindeTijdvak,' \
+                      'gebieden:buurtenVolgnummer,gebieden:buurtenIdentificatie,' \
+                      'gebieden:buurtenCode,gebieden:buurtenNaam,' \
+                      'gebieden:wijkenVolgnummer,gebieden:wijkenIdentificatie,' \
+                      'gebieden:wijkenCode,gebieden:wijkenNaam,' \
+                      'gebieden:stadsdelenVolgnummer,gebieden:stadsdelenIdentificatie,' \
+                      'gebieden:stadsdelenCode,gebieden:stadsdelenNaam,geometrie'
         }
     }

--- a/src/gobexport/exporter/config/gebieden.py
+++ b/src/gobexport/exporter/config/gebieden.py
@@ -69,9 +69,9 @@ class StadsdelenExportConfig:
             'endpoint': '/gob/toestanden/?collections=gebieden:stadsdelen',
             'filename': 'ActueelEnHistorie_CSV/GBD_stadsdeel.csv',
             'mime_type': 'plain/text',
-            'format': 'identificatie,volgnummer,registratiedatum,code,naam,' \
-                      'datumBeginGeldigheid,datumEindeGeldigheid,documentdatum,' \
-                      'documentnummer,datumBeginTijdvak,datumEindeTijdvak,' \
+            'format': 'identificatie,volgnummer,registratiedatum,code,naam,'
+                      'datumBeginGeldigheid,datumEindeGeldigheid,documentdatum,'
+                      'documentnummer,datumBeginTijdvak,datumEindeTijdvak,'
                       'geometrie'
         }
     }
@@ -129,10 +129,10 @@ class WijkenExportConfig:
             'endpoint': '/gob/toestanden/?collections=gebieden:wijken,gebieden:stadsdelen',
             'filename': 'ActueelEnHistorie_CSV/GBD_wijk.csv',
             'mime_type': 'plain/text',
-            'format': 'identificatie,volgnummer,registratiedatum,code,naam,' \
-                      'datumBeginGeldigheid,datumEindeGeldigheid,documentdatum,' \
-                      'documentnummer,cbsCode,datumBeginTijdvak,datumEindeTijdvak,' \
-                      'gebieden:stadsdelenVolgnummer,gebieden:stadsdelenIdentificatie,' \
+            'format': 'identificatie,volgnummer,registratiedatum,code,naam,'
+                      'datumBeginGeldigheid,datumEindeGeldigheid,documentdatum,'
+                      'documentnummer,cbsCode,datumBeginTijdvak,datumEindeTijdvak,'
+                      'gebieden:stadsdelenVolgnummer,gebieden:stadsdelenIdentificatie,'
                       'gebieden:stadsdelenCode,gebieden:stadsdelenNaam,geometrie'
         }
     }
@@ -193,12 +193,12 @@ class BuurtenExportConfig:
             'endpoint': '/gob/toestanden/?collections=gebieden:buurten,gebieden:wijken,gebieden:stadsdelen',
             'filename': 'ActueelEnHistorie_CSV/GBD_buurt.csv',
             'mime_type': 'plain/text',
-            'format': 'identificatie,volgnummer,registratiedatum,code,naam,' \
-                      'datumBeginGeldigheid,datumEindeGeldigheid,documentdatum,' \
-                      'documentnummer,cbsCode,datumBeginTijdvak,datumEindeTijdvak,' \
-                      'gebieden:wijkenVolgnummer,gebieden:wijkenIdentificatie,' \
-                      'gebieden:wijkenCode,gebieden:wijkenNaam,' \
-                      'gebieden:stadsdelenVolgnummer,gebieden:stadsdelenIdentificatie,' \
+            'format': 'identificatie,volgnummer,registratiedatum,code,naam,'
+                      'datumBeginGeldigheid,datumEindeGeldigheid,documentdatum,'
+                      'documentnummer,cbsCode,datumBeginTijdvak,datumEindeTijdvak,'
+                      'gebieden:wijkenVolgnummer,gebieden:wijkenIdentificatie,'
+                      'gebieden:wijkenCode,gebieden:wijkenNaam,'
+                      'gebieden:stadsdelenVolgnummer,gebieden:stadsdelenIdentificatie,'
                       'gebieden:stadsdelenCode,gebieden:stadsdelenNaam,geometrie'
         }
     }
@@ -262,14 +262,14 @@ class BouwblokkenExportConfig:
                         'gebieden:buurten,gebieden:wijken,gebieden:stadsdelen',
             'filename': 'ActueelEnHistorie_CSV/GBD_bouwblok.csv',
             'mime_type': 'plain/text',
-            'format': 'identificatie,volgnummer,registratiedatum,code,naam,' \
-                      'datumBeginGeldigheid,datumEindeGeldigheid,documentdatum,' \
-                      'documentnummer,cbsCode,datumBeginTijdvak,datumEindeTijdvak,' \
-                      'gebieden:buurtenVolgnummer,gebieden:buurtenIdentificatie,' \
-                      'gebieden:buurtenCode,gebieden:buurtenNaam,' \
-                      'gebieden:wijkenVolgnummer,gebieden:wijkenIdentificatie,' \
-                      'gebieden:wijkenCode,gebieden:wijkenNaam,' \
-                      'gebieden:stadsdelenVolgnummer,gebieden:stadsdelenIdentificatie,' \
+            'format': 'identificatie,volgnummer,registratiedatum,code,naam,'
+                      'datumBeginGeldigheid,datumEindeGeldigheid,documentdatum,'
+                      'documentnummer,cbsCode,datumBeginTijdvak,datumEindeTijdvak,'
+                      'gebieden:buurtenVolgnummer,gebieden:buurtenIdentificatie,'
+                      'gebieden:buurtenCode,gebieden:buurtenNaam,'
+                      'gebieden:wijkenVolgnummer,gebieden:wijkenIdentificatie,'
+                      'gebieden:wijkenCode,gebieden:wijkenNaam,'
+                      'gebieden:stadsdelenVolgnummer,gebieden:stadsdelenIdentificatie,'
                       'gebieden:stadsdelenCode,gebieden:stadsdelenNaam,geometrie'
         }
     }

--- a/src/gobexport/exporter/csv.py
+++ b/src/gobexport/exporter/csv.py
@@ -9,7 +9,8 @@ def csv_exporter(api, file, format=None):
         # Get the headers from the first record in the API
         for entity in api:
             if row_count == 0:
-                writer = csv.DictWriter(fp, fieldnames=[k for k in entity.keys()], delimiter=';')
+                fieldnames = format.split(',') if format else [k for k in entity.keys()]
+                writer = csv.DictWriter(fp, fieldnames=fieldnames, delimiter=';')
                 writer.writeheader()
 
             # Convert geojson to wkt


### PR DESCRIPTION
The order of some of the columns in the csv export needed to be changed to match specifications. Format definitions were added to ensure column order in csv configs and some esri exports were modified.