### PR TITLE
Add utf8-bom to csv files

### DIFF
--- a/src/gobexport/exporter/config/gebieden.py
+++ b/src/gobexport/exporter/config/gebieden.py
@@ -116,6 +116,8 @@ class StadsdelenExportConfig:
             node {
               identificatie
               naam
+              beginGeldigheid
+              eindGeldigheid
             }
           }
         }
@@ -239,6 +241,16 @@ class GGPGebiedenExportConfig:
               naam
               beginGeldigheid
               eindGeldigheid
+              ligtInGemeente(active: false) {
+                edges {
+                  node {
+                    identificatie
+                    naam
+                    beginGeldigheid
+                    eindGeldigheid
+                  }
+                }
+              }
             }
           }
         }
@@ -360,6 +372,16 @@ class GGWGebiedenExportConfig:
               naam
               beginGeldigheid
               eindGeldigheid
+              ligtInGemeente(active: false) {
+                edges {
+                  node {
+                    identificatie
+                    naam
+                    beginGeldigheid
+                    eindGeldigheid
+                  }
+                }
+              }
             }
           }
         }
@@ -507,6 +529,16 @@ class WijkenExportConfig:
               naam
               beginGeldigheid
               eindGeldigheid
+              ligtInGemeente(active: false) {
+                edges {
+                  node {
+                    identificatie
+                    naam
+                    beginGeldigheid
+                    eindGeldigheid
+                  }
+                }
+              }
             }
           }
         }
@@ -695,6 +727,16 @@ class BuurtenExportConfig:
                     naam
                     beginGeldigheid
                     eindGeldigheid
+                    ligtInGemeente(active: false) {
+                      edges {
+                        node {
+                          identificatie
+                          naam
+                          beginGeldigheid
+                          eindGeldigheid
+                        }
+                      }
+                    }
                   }
                 }
               }
@@ -889,6 +931,16 @@ class BouwblokkenExportConfig:
                           naam
                           beginGeldigheid
                           eindGeldigheid
+                          ligtInGemeente(active: false) {
+                            edges {
+                              node {
+                                identificatie
+                                naam
+                                beginGeldigheid
+                                eindGeldigheid
+                              }
+                            }
+                          }
                         }
                       }
                     }

--- a/src/gobexport/exporter/csv.py
+++ b/src/gobexport/exporter/csv.py
@@ -84,7 +84,7 @@ def csv_exporter(api, file, format=None, append=False, filter: EntityFilter=None
     if append:
         _ensure_fieldnames_match_existing_file(fieldnames, file)
 
-    with open(file, 'a' if append else 'w') as fp, ProgressTicker(f"Export entities", 10000) as progress:
+    with open(file, 'a' if append else 'w', encoding='utf-8-sig') as fp, ProgressTicker(f"Export entities", 10000) as progress:
         # Get the fieldnames from the mapping
         writer = csv.DictWriter(fp, fieldnames=fieldnames, delimiter=';')
 

--- a/src/gobexport/exporter/csv.py
+++ b/src/gobexport/exporter/csv.py
@@ -84,7 +84,8 @@ def csv_exporter(api, file, format=None, append=False, filter: EntityFilter=None
     if append:
         _ensure_fieldnames_match_existing_file(fieldnames, file)
 
-    with open(file, 'a' if append else 'w', encoding='utf-8-sig') as fp, ProgressTicker(f"Export entities", 10000) as progress:
+    with open(file, 'a' if append else 'w', encoding='utf-8-sig') as fp, \
+            ProgressTicker(f"Export entities", 10000) as progress:
         # Get the fieldnames from the mapping
         writer = csv.DictWriter(fp, fieldnames=fieldnames, delimiter=';')
 

--- a/src/tests/exporter/test_export.py
+++ b/src/tests/exporter/test_export.py
@@ -84,7 +84,7 @@ class MockFile:
         MockFile.s += s
 
 
-def mock_open(file, mode):
+def mock_open(file, mode, encoding='utf-8-sig'):
     return MockFile()
 
 
@@ -208,4 +208,3 @@ class TestExportToFile(TestCase):
                                          'the format',
                                          append=False,
                                          filter=mock_group_filter.return_value)
-


### PR DESCRIPTION
UTF-8 BOM was added to help excel users on importing data.

Also fixes an error with gebieden historic errors on gemeente relation. Start and end validity weren’t requested in the graphql query, which caused an error on stadsdelen export