### PR TITLE
Export woonplaatsen with history

### DIFF
--- a/src/gobexport/exporter/config/bag.py
+++ b/src/gobexport/exporter/config/bag.py
@@ -1,6 +1,8 @@
 from gobexport.exporter.csv import csv_exporter
 from gobexport.exporter.esri import esri_exporter
 
+from gobexport.formatter.geometry import format_geometry
+
 
 """BAG export config
 
@@ -84,6 +86,36 @@ class WoonplaatsenExportConfig:
 }
 '''
 
+    query_history = '''
+{
+  bagWoonplaatsen(active: false) {
+    edges {
+      node {
+        identificatie
+        volgnummer
+        aanduidingInOnderzoek
+        geconstateerd
+        naam
+        beginGeldigheid
+        eindGeldigheid
+        documentdatum
+        documentnummer
+        status
+        ligtInGemeente {
+          edges {
+            node {
+              identificatie
+              naam
+            }
+          }
+        }
+        geometrie
+      }
+    }
+  }
+}
+'''
+
     format = BAGDefaultFormat({
         'identificatie': 'identificatie',
         'aanduidingInOnderzoek': 'aanduidingInOnderzoek',
@@ -96,7 +128,11 @@ class WoonplaatsenExportConfig:
         'status': 'status.omschrijving',
         'ligtIn:BRK.GME.identificatie': 'ligtInGemeente.identificatie',
         'ligtIn:BRK.GME.naam': 'ligtInGemeente.naam',
-        'geometrie': 'geometrie',
+        'geometrie': {
+            'action': 'format',
+            'formatter': format_geometry,
+            'value': 'geometrie'
+        },
     })
 
     esri_format = BAGDefaultFormat({
@@ -126,8 +162,13 @@ class WoonplaatsenExportConfig:
         'documentnummer': 'documentnummer',
         'status': 'status.omschrijving',
         'ligtIn:BRK.GME.identificatie': 'ligtInGemeente.identificatie',
+        'ligtIn:BRK.GME.volgnummer': '',
         'ligtIn:BRK.GME.naam': 'ligtInGemeente.naam',
-        'geometrie': 'geometrie',
+        'geometrie': {
+            'action': 'format',
+            'formatter': format_geometry,
+            'value': 'geometrie'
+        },
     })
 
     products = {
@@ -160,6 +201,14 @@ class WoonplaatsenExportConfig:
                 },
             ],
             'query': query_actueel
+        },
+        'csv_history': {
+            'api_type': 'graphql_streaming',
+            'exporter': csv_exporter,
+            'filename': 'CSV_ActueelEnHistorie/BAG_woonplaats_ActueelEnHistorie.csv',
+            'mime_type': 'plain/text',
+            'format': history_format.get_format(),
+            'query': query_history
         },
     }
 
@@ -210,7 +259,11 @@ class OpenbareruimtesExportConfig:
         'status': 'status.omschrijving',
         'ligtIn:BAG.WPS.identificatie': 'ligtInWoonplaats.identificatie',
         'ligtIn:BAG.WPS.naam': 'ligtInWoonplaats.naam',
-        'geometrie': 'geometrie',
+        'geometrie': {
+            'action': 'format',
+            'formatter': format_geometry,
+            'value': 'geometrie'
+        },
     })
 
     esri_format = BAGDefaultFormat({
@@ -248,7 +301,11 @@ class OpenbareruimtesExportConfig:
         'ligtIn:BAG.WPS.naam': 'ligtInWoonplaats.naam',
         'beginTijdvak': 'beginTijdvak',
         'eindTijdvak': 'eindTijdvak',
-        'geometrie': 'geometrie',
+        'geometrie': {
+            'action': 'format',
+            'formatter': format_geometry,
+            'value': 'geometrie'
+        },
     })
 
     products = {
@@ -435,7 +492,11 @@ class VerblijfsobjectenExportConfig:
         'ligtIn:GBD.SDL.identificatie': 'ligtInStadsdeel.identificatie',
         'ligtIn:GBD.SDL.code': 'ligtInStadsdeel.code',
         'ligtIn:GBD.SDL.naam': 'ligtInStadsdeel.naam',
-        'geometrie': 'geometrie'
+        'geometrie': {
+            'action': 'format',
+            'formatter': format_geometry,
+            'value': 'geometrie'
+        },
     })
 
     esri_format = BAGDefaultFormat({
@@ -564,7 +625,11 @@ class VerblijfsobjectenExportConfig:
         'ligtIn:GBD.SDL.naam': 'ligtInStadsdeel.naam',
         'beginTijdvak': 'beginTijdvak',
         'eindTijdvak': 'eindTijdvak',
-        'geometrie': 'geometrie'
+        'geometrie': {
+            'action': 'format',
+            'formatter': format_geometry,
+            'value': 'geometrie'
+        },
     })
 
     products = {
@@ -738,7 +803,11 @@ class StandplaatsenExportConfig:
         'ligtIn:GBD.SDL.identificatie': 'ligtInStadsdeel.identificatie',
         'ligtIn:GBD.SDL.code': 'ligtInStadsdeel.code',
         'ligtIn:GBD.SDL.naam': 'ligtInStadsdeel.naam',
-        'geometrie': 'geometrie'
+        'geometrie': {
+            'action': 'format',
+            'formatter': format_geometry,
+            'value': 'geometrie'
+        },
     })
 
     esri_format = BAGDefaultFormat({
@@ -829,7 +898,11 @@ class StandplaatsenExportConfig:
         'ligtIn:GBD.SDL.naam': 'ligtInStadsdeel.naam',
         'beginTijdvak': 'beginTijdvak',
         'eindTijdvak': 'eindTijdvak',
-        'geometrie': 'geometrie'
+        'geometrie': {
+            'action': 'format',
+            'formatter': format_geometry,
+            'value': 'geometrie'
+        },
     })
 
     products = {
@@ -1005,7 +1078,11 @@ class LigplaatsenExportConfig:
         'ligtIn:GBD.SDL.identificatie': 'ligtInStadsdeel.identificatie',
         'ligtIn:GBD.SDL.code': 'ligtInStadsdeel.code',
         'ligtIn:GBD.SDL.naam': 'ligtInStadsdeel.naam',
-        'geometrie': 'geometrie'
+        'geometrie': {
+            'action': 'format',
+            'formatter': format_geometry,
+            'value': 'geometrie'
+        },
     })
 
     esri_format = BAGDefaultFormat({
@@ -1096,7 +1173,11 @@ class LigplaatsenExportConfig:
         'ligtIn:GBD.SDL.naam': 'ligtInStadsdeel.naam',
         'beginTijdvak': 'beginTijdvak',
         'eindTijdvak': 'eindTijdvak',
-        'geometrie': 'geometrie'
+        'geometrie': {
+            'action': 'format',
+            'formatter': format_geometry,
+            'value': 'geometrie'
+        },
     })
 
     products = {
@@ -1168,7 +1249,11 @@ class PandenExportConfig:
         'ligtIn:GBD.SDL.identificatie': 'ligtInStadsdeel.identificatie',
         'ligtIn:GBD.SDL.code': 'ligtInStadsdeel.code',
         'ligtIn:GBD.SDL.naam': 'ligtInStadsdeel.naam',
-        'geometrie': 'geometrie'
+        'geometrie': {
+            'action': 'format',
+            'formatter': format_geometry,
+            'value': 'geometrie'
+        },
     })
 
     esri_format = BAGDefaultFormat({
@@ -1247,7 +1332,11 @@ class PandenExportConfig:
         'ligtIn:GBD.SDL.volgnummer': 'ligtInStadsdeel.volgnummer',
         'ligtIn:GBD.SDL.code': 'ligtInStadsdeel.code',
         'ligtIn:GBD.SDL.naam': 'ligtInStadsdeel.naam',
-        'geometrie': 'geometrie'
+        'geometrie': {
+            'action': 'format',
+            'formatter': format_geometry,
+            'value': 'geometrie'
+        },
     })
 
     products = {
@@ -1288,7 +1377,7 @@ class BrondocumentenExportConfig:
         'csv_actueel': {
             'endpoint': '/gob/bag/brondocumenten/?view=enhanced&ndjson=true',
             'exporter': csv_exporter,
-            'filename': 'CSV_Actueel/BAG_brondocument.csv',
+            'filename': 'CSV_Actueel/BAG_brondocument_Actueel.csv',
             'mime_type': 'plain/text',
             'format': {
                 'dossier': 'dossier',

--- a/src/gobexport/exporter/config/brk.py
+++ b/src/gobexport/exporter/config/brk.py
@@ -5,12 +5,15 @@ from fractions import Fraction
 from operator import itemgetter
 from typing import Optional
 
+from gobexport.config import get_host
+
 from gobexport.exporter.csv import csv_exporter
 from gobexport.exporter.esri import esri_exporter
 
 from gobexport.filters.notempty_filter import NotEmptyFilter
 
-from gobexport.config import get_host
+from gobexport.formatter.geometry import format_geometry
+
 
 FILE_TYPE_MAPPING = {
     'csv': {
@@ -1159,7 +1162,11 @@ class KadastraleobjectenCsvFormat:
             'SJT_VVE_UIT_EIGENDOM': 'betrokkenBijAppartementsrechtsplitsingVve.[0].statutaireNaam',
             'KOT_INONDERZOEK': 'inOnderzoek',
             'KOT_MODIFICATION': 'wijzigingsdatum',
-            'GEOMETRIE': 'geometrie'
+            'GEOMETRIE': {
+                'action': 'format',
+                'formatter': format_geometry,
+                'value': 'geometrie'
+            },
         }
 
 
@@ -1318,7 +1325,11 @@ class GemeentesExportConfig:
             'format': {
                 'naam': 'naam',
                 'identificatie': 'identificatie',
-                'geometrie': 'geometrie'
+                'geometrie': {
+                    'action': 'format',
+                    'formatter': format_geometry,
+                    'value': 'geometrie'
+                },
             }
         },
         'shape': {
@@ -1394,7 +1405,11 @@ class BijpijlingExportConfig:
                 'PERCEELNR': 'perceelnummer',
                 'INDEXLTR': 'indexletter',
                 'INDEXNR': 'indexnummer',
-                'geometrie': 'bijpijlingGeometrie',
+                'geometrie': {
+                    'action': 'format',
+                    'formatter': format_geometry,
+                    'value': 'bijpijlingGeometrie'
+                },
             },
             'extra_files': [
                 {
@@ -1445,7 +1460,11 @@ class PerceelnummerEsriFormat:
                     'value': '0.000',
                 }
             },
-            'geometrie': 'plaatscoordinaten',
+            'geometrie': {
+                'action': 'format',
+                'formatter': format_geometry,
+                'value': 'plaatscoordinaten'
+            },
         }
 
 

--- a/src/gobexport/exporter/config/gebieden.py
+++ b/src/gobexport/exporter/config/gebieden.py
@@ -1,6 +1,8 @@
 from gobexport.exporter.csv import csv_exporter
 from gobexport.exporter.esri import esri_exporter
 
+from gobexport.formatter.geometry import format_geometry
+
 
 """Gebieden export config
 
@@ -40,7 +42,11 @@ class StadsdelenExportConfig:
                 'documentnummer': 'documentnummer',
                 'ligtIn:BRK.GME.identificatie': 'ligtInGemeente.identificatie',
                 'ligtIn:BRK.GME.naam': 'ligtInGemeente.naam',
-                'geometrie': 'geometrie',
+                'geometrie': {
+                    'action': 'format',
+                    'formatter': format_geometry,
+                    'value': 'geometrie'
+                },
             }
         },
         'esri_actueel': {
@@ -58,7 +64,6 @@ class StadsdelenExportConfig:
                 'docnummer': 'documentnummer',
                 'gme_id': 'ligtInGemeente.identificatie',
                 'gme_naam': 'ligtInGemeente.naam',
-                'geometrie': 'geometrie'
             },
             'extra_files': [
                 {
@@ -96,7 +101,11 @@ class StadsdelenExportConfig:
                 'ligtIn:BRK.GME.naam': 'ligtInGemeente.naam',
                 'beginTijdvak': 'beginTijdvak',
                 'eindTijdvak': 'eindTijdvak',
-                'geometrie': 'geometrie',
+                'geometrie': {
+                    'action': 'format',
+                    'formatter': format_geometry,
+                    'value': 'geometrie'
+                },
             },
             'query': """
 {
@@ -153,7 +162,11 @@ class GGPGebiedenExportConfig:
                 'ligtIn:GBD.SDL.naam': 'ligtInStadsdeel.naam',
                 'ligtIn:BRK.GME.identificatie': 'ligtInGemeente.identificatie',
                 'ligtIn:BRK.GME.naam': 'ligtInGemeente.naam',
-                'geometrie': 'geometrie',
+                'geometrie': {
+                    'action': 'format',
+                    'formatter': format_geometry,
+                    'value': 'geometrie'
+                },
 
             }
         },
@@ -216,7 +229,11 @@ class GGPGebiedenExportConfig:
                 'ligtIn:BRK.GME.naam': 'ligtInGemeente.naam',
                 'beginTijdvak': 'beginTijdvak',
                 'eindTijdvak': 'eindTijdvak',
-                'geometrie': 'geometrie',
+                'geometrie': {
+                    'action': 'format',
+                    'formatter': format_geometry,
+                    'value': 'geometrie'
+                },
             },
             'query': '''
 {
@@ -285,7 +302,11 @@ class GGWGebiedenExportConfig:
                 'ligtIn:GBD.SDL.naam': 'ligtInStadsdeel.naam',
                 'ligtIn:BRK.GME.identificatie': 'ligtInGemeente.identificatie',
                 'ligtIn:BRK.GME.naam': 'ligtInGemeente.naam',
-                'geometrie': 'geometrie',
+                'geometrie': {
+                    'action': 'format',
+                    'formatter': format_geometry,
+                    'value': 'geometrie'
+                },
             }
         },
         'esri_actueel': {
@@ -347,7 +368,11 @@ class GGWGebiedenExportConfig:
                 'ligtIn:BRK.GME.naam': 'ligtInGemeente.naam',
                 'beginTijdvak': 'beginTijdvak',
                 'eindTijdvak': 'eindTijdvak',
-                'geometrie': 'geometrie',
+                'geometrie': {
+                    'action': 'format',
+                    'formatter': format_geometry,
+                    'value': 'geometrie'
+                },
             },
             'query': '''
 {
@@ -420,7 +445,11 @@ class WijkenExportConfig:
                 'ligtIn:GBD.SDL.naam': 'ligtInStadsdeel.naam',
                 'ligtIn:BRK.GME.identificatie': 'ligtInGemeente.identificatie',
                 'ligtIn:BRK.GME.naam': 'ligtInGemeente.naam',
-                'geometrie': 'geometrie',
+                'geometrie': {
+                    'action': 'format',
+                    'formatter': format_geometry,
+                    'value': 'geometrie'
+                },
             }
         },
         'esri_actueel': {
@@ -491,7 +520,11 @@ class WijkenExportConfig:
                 'ligtIn:BRK.GME.naam': 'ligtInGemeente.naam',
                 'beginTijdvak': 'beginTijdvak',
                 'eindTijdvak': 'eindTijdvak',
-                'geometrie': 'geometrie',
+                'geometrie': {
+                    'action': 'format',
+                    'formatter': format_geometry,
+                    'value': 'geometrie'
+                },
             },
             'query': '''
 {
@@ -583,7 +616,11 @@ class BuurtenExportConfig:
                 'ligtIn:GBD.SDL.naam': 'ligtInStadsdeel.naam',
                 'ligtIn:BRK.GME.identificatie': 'ligtInGemeente.identificatie',
                 'ligtIn:BRK.GME.naam': 'ligtInGemeente.naam',
-                'geometrie': 'geometrie',
+                'geometrie': {
+                    'action': 'format',
+                    'formatter': format_geometry,
+                    'value': 'geometrie'
+                },
             }
         },
         'esri_actueel': {
@@ -668,7 +705,11 @@ class BuurtenExportConfig:
                 'ligtIn:BRK.GME.naam': 'ligtInGemeente.naam',
                 'beginTijdvak': 'beginTijdvak',
                 'eindTijdvak': 'eindTijdvak',
-                'geometrie': 'geometrie',
+                'geometrie': {
+                    'action': 'format',
+                    'formatter': format_geometry,
+                    'value': 'geometrie'
+                },
             },
             'query': '''
 {
@@ -783,7 +824,11 @@ class BouwblokkenExportConfig:
                 'ligtIn:GBD.SDL.naam': 'ligtInStadsdeel.naam',
                 'ligtIn:BRK.GME.identificatie': 'ligtInGemeente.identificatie',
                 'ligtIn:BRK.GME.naam': 'ligtInGemeente.naam',
-                'geometrie': 'geometrie',
+                'geometrie': {
+                    'action': 'format',
+                    'formatter': format_geometry,
+                    'value': 'geometrie'
+                },
             }
         },
         'esri_actueel': {
@@ -867,7 +912,11 @@ class BouwblokkenExportConfig:
                 'ligtIn:BRK.GME.naam': 'ligtInGemeente.naam',
                 'beginTijdvak': 'beginTijdvak',
                 'eindTijdvak': 'eindTijdvak',
-                'geometrie': 'geometrie',
+                'geometrie': {
+                    'action': 'format',
+                    'formatter': format_geometry,
+                    'value': 'geometrie'
+                },
             },
             'query': '''
 {

--- a/src/gobexport/exporter/csv.py
+++ b/src/gobexport/exporter/csv.py
@@ -1,7 +1,5 @@
 import csv
 
-from shapely.geometry import shape
-
 from gobcore.exceptions import GOBException
 from gobcore.utils import ProgressTicker
 
@@ -102,10 +100,6 @@ def csv_exporter(api, file, format=None, append=False, filter: EntityFilter=None
             row = {}
             for attribute_name, lookup_key in mapping.items():
                 row[attribute_name] = get_entity_value(entity, lookup_key)
-
-            # Convert geojson to wkt
-            if 'geometrie' in row:
-                row['geometrie'] = shape(entity['geometrie']).wkt if entity['geometrie'] else ''
 
             writer.writerow(row)
             row_count += 1

--- a/src/gobexport/exporter/esri.py
+++ b/src/gobexport/exporter/esri.py
@@ -86,7 +86,7 @@ def esri_exporter(api, file, format=None, append=False, filter: EntityFilter=Non
                 dstlayer = dstfile.CreateLayer("layer", spatialref, geom_type=geometry_type)
 
                 # Add all field definitions, but skip geometrie
-                all_fields = {k: v for k, v in format.items() if k is not 'geometrie'}
+                all_fields = {k: v for k, v in format.items() if k is not geometry_field}
                 add_field_definitions(dstlayer, all_fields.keys())
 
             feature = ogr.Feature(dstlayer.GetLayerDefn())

--- a/src/gobexport/formatter/geometry.py
+++ b/src/gobexport/formatter/geometry.py
@@ -1,0 +1,14 @@
+from shapely.geometry import shape
+
+
+def format_geometry(value):
+    """Returns geometry as wkt string for file exports
+
+    :param value item:
+    :return:
+    """
+    if isinstance(value, dict):
+        # Transform geojson to wkt, if None return an empty string
+        return shape(value).wkt
+    else:
+        return value if value else ''

--- a/src/tests/exporter/test_csv.py
+++ b/src/tests/exporter/test_csv.py
@@ -56,9 +56,8 @@ class TestCsvExporter(TestCase):
     @patch("gobexport.exporter.csv.build_mapping_from_format")
     @patch("builtins.open", mock_open())
     @patch("gobexport.exporter.csv.csv")
-    @patch("gobexport.exporter.csv.shape")
     @patch("gobexport.exporter.csv.ProgressTicker")
-    def test_csv_exporter_filter(self, mock_progress_ticker, mock_shape, mock_csv, mock_build_mapping,
+    def test_csv_exporter_filter(self, mock_progress_ticker, mock_csv, mock_build_mapping,
                                  mock_match_fieldnames):
         api = ['a']
         file = ""
@@ -74,4 +73,3 @@ class TestCsvExporter(TestCase):
 
         mock_filter.filter.assert_called_with('a')
         mock_tick.tick.assert_not_called()
-

--- a/src/tests/exporter/test_export.py
+++ b/src/tests/exporter/test_export.py
@@ -10,6 +10,8 @@ from gobexport.exporter.dat import dat_exporter
 from gobexport.exporter.csv import csv_exporter
 from gobexport.exporter.esri import esri_exporter
 
+from gobexport.formatter.geometry import format_geometry
+
 
 def before_each(monkeypatch):
     import gobexport.exporter
@@ -51,7 +53,11 @@ class MockConfig:
             'format': {
                 'identificatie': 'identificatie',
                 'boolean': 'boolean',
-                'geometrie': 'geometrie',
+                'geometrie': {
+                    'action': 'format',
+                    'formatter': format_geometry,
+                    'value': 'geometrie'
+                },
             },
             'query': 'any query'
         },

--- a/src/tests/formatter/test_geometry.py
+++ b/src/tests/formatter/test_geometry.py
@@ -1,0 +1,43 @@
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from gobexport.formatter.geometry import format_geometry
+
+
+class MockShape:
+
+    def __init__(self, value):
+        self.value = f"{value['type'].upper()} ({value['coordinates'][0]} {value['coordinates'][1]})"
+
+    @property
+    def wkt(self):
+        return self.value
+
+class TestGeometryFormatter(TestCase):
+
+    @patch("gobexport.formatter.geometry.shape")
+    def test_format_geometry_geojson(self, mock_shape):
+        geojson = {'type': 'Point', 'coordinates': [125.6, 10.1]}
+        expected_result = 'POINT (125.6 10.1)'
+
+        mock_shape.return_value = MockShape(geojson)
+
+        self.assertEqual(format_geometry(geojson), expected_result)
+
+    def test_format_geometry_invalid_geojson(self):
+        geojson = {'type': 'Invalid', 'false': 'attribute'}
+
+        with self.assertRaises(ValueError):
+            format_geometry(geojson)
+
+    def test_format_geometry_none(self):
+        geojson = None
+        expected_result = ''
+
+        self.assertEqual(format_geometry(geojson), expected_result)
+
+    def test_format_geometry_wkt(self):
+        wkt = 'POINT (125.6 10.1)'
+        expected_result = 'POINT (125.6 10.1)'
+
+        self.assertEqual(format_geometry(wkt), expected_result)


### PR DESCRIPTION
BAG-1004

Woonplaatsen with history is being exported. In the streaming graphql api geometry was returned as wkt instead of geojson. A formatter was added to transform the value instead of always handling this in the csv exporter, which led to changing the other export definitions.