### PR TITLE
Add UVA2 WPL export

### DIFF
--- a/src/gobexport/exporter/__init__.py
+++ b/src/gobexport/exporter/__init__.py
@@ -1,5 +1,6 @@
 from gobexport.api import API
 from gobexport.exporter.config import bag, brk, gebieden, meetbouten, nap, test, wkpb
+from gobexport.exporter.config.uva2 import add_uva2_products
 from gobexport.graphql import GraphQL
 from gobexport.graphql_streaming import GraphQLStreaming
 from gobexport.buffered_iterable import BufferedIterable
@@ -53,6 +54,9 @@ CONFIG_MAPPING = {
         'brondocumenten': wkpb.BrondocumentenExportConfig,
     }
 }
+
+# Add UVA2 product to BAG exports
+add_uva2_products()
 
 
 def product_source(product):

--- a/src/gobexport/exporter/config/brk.py
+++ b/src/gobexport/exporter/config/brk.py
@@ -745,6 +745,7 @@ class ZakelijkerechtenCsvFormat(BrkCsvFormat):
                         'length': 5,
                         'character': '0',
                         'value': 'rustOpKadastraalobject.[0].perceelnummer',
+                        'fill_type': 'rjust',
                     },
                     {
                         'action': 'literal',
@@ -760,6 +761,7 @@ class ZakelijkerechtenCsvFormat(BrkCsvFormat):
                         'length': 4,
                         'character': '0',
                         'value': 'rustOpKadastraalobject.[0].indexnummer',
+                        'fill_type': 'rjust',
                     }
                 ]
             },

--- a/src/gobexport/exporter/config/uva2.py
+++ b/src/gobexport/exporter/config/uva2.py
@@ -1,0 +1,108 @@
+from datetime import date
+import dateutil.parser as dt_parser
+
+from gobexport.exporter.config.bag import WoonplaatsenExportConfig
+from gobexport.exporter.uva2 import uva2_exporter
+
+UVA2_DATE_FORMAT = '%Y%m%d'
+
+
+def add_uva2_products():
+    _add_woonplaatsen_uva2_config()
+
+
+def format_uva2_date(datetimestr):
+    if not datetimestr:
+        # Input variable may be empty
+        return None
+
+    try:
+        dt = dt_parser.parse(datetimestr)
+        return dt.strftime(UVA2_DATE_FORMAT)
+    except ValueError:
+        # If invalid datetimestr, just return the original string so that no data is lost
+        return datetimestr
+
+
+def get_uva2_filename(abbreviation):
+    assert abbreviation, "UVA2 requires an abbreviation"
+
+    publish_date = date.today().strftime(UVA2_DATE_FORMAT)
+    return f"UVA2_Actueel/{abbreviation}_{publish_date}_N_{publish_date}_{publish_date}.UVA2"
+
+
+def _add_woonplaatsen_uva2_config():
+    uva2_query = """
+{
+  bagWoonplaatsen {
+    edges {
+      node {
+        amsterdamseSleutel
+        identificatie
+        naam
+        documentdatum
+        documentnummer
+        beginGeldigheid
+        eindGeldigheid
+        ligtInGemeente {
+          edges {
+            node {
+              identificatie
+            }
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+    WoonplaatsenExportConfig.products['uva2'] = {
+        'api_type': 'graphql',
+        'exporter': uva2_exporter,
+        'filename': get_uva2_filename("WPL"),
+        'mime_type': 'plain/text',
+        'format': {
+            'sleutelverzendend': 'amsterdamseSleutel',
+            'Woonplaatsidentificatie': 'identificatie',
+            'Woonplaatsnaam': 'naam',
+            'DocumentdatumMutatieWoonplaats': {
+                'action': 'format',
+                'formatter': format_uva2_date,
+                'value': 'documentdatum',
+            },
+            'DocumentnummerMutatieWoonplaats': 'documentnummer',
+            'WoonplaatsPTTSchrijfwijze': '',
+            'Mutatie-gebruiker': '',
+            'Indicatie-vervallen': '',
+            'TijdvakGeldigheid/begindatumTijdvakGeldigheid': {
+                'action': 'format',
+                'formatter': format_uva2_date,
+                'value': 'beginGeldigheid',
+            },
+            'TijdvakGeldigheid/einddatumTijdvakGeldigheid': {
+                'action': 'format',
+                'formatter': format_uva2_date,
+                'value': 'eindGeldigheid',
+            },
+            'WPLGME/GME/sleutelVerzendend': {
+                'action': 'fill',
+                'length': 14,
+                'character': '0',
+                'value': 'ligtInGemeente.[0].identificatie',
+                'fill_type': 'ljust'
+            },
+            'WPLGME/GME/Gemeentecode': 'ligtInGemeente.[0].identificatie',
+            'WPLGME/TijdvakRelatie/begindatumRelatie': {
+                'action': 'format',
+                'formatter': format_uva2_date,
+                'value': 'beginGeldigheid',
+            },
+            'WPLGME/TijdvakRelatie/einddatumRelatie': {
+                'action': 'format',
+                'formatter': format_uva2_date,
+                'value': 'eindGeldigheid',
+            }
+        },
+        'query': uva2_query
+    }

--- a/src/gobexport/exporter/utils.py
+++ b/src/gobexport/exporter/utils.py
@@ -54,10 +54,15 @@ def _evaluate_literal_action(action: dict):
 
 
 def _evaluate_fill_action(entity: dict, action: dict):
-    assert all([key in action for key in ['length', 'value', 'character']])
+    assert all([key in action for key in ['length', 'value', 'character', 'fill_type']])
+    assert action['fill_type'] in ['rjust', 'ljust'], "A valid fill type must be supplied (rjust, ljust)"
 
     value = str(get_entity_value(entity, action['value']))
-    return value.rjust(action['length'], action['character'])
+
+    if action['fill_type'] == 'rjust':
+        return value.rjust(action['length'], action['character'])
+    elif action['fill_type'] == 'ljust':
+        return value.ljust(action['length'], action['character'])
 
 
 def _evaluate_format_action(entity: dict, action: dict):

--- a/src/gobexport/exporter/uva2.py
+++ b/src/gobexport/exporter/uva2.py
@@ -1,0 +1,88 @@
+from datetime import date
+
+from gobcore.utils import ProgressTicker
+
+from gobexport.exporter.csv import build_mapping_from_format
+from gobexport.exporter.utils import get_entity_value
+from gobexport.filters.entity_filter import EntityFilter
+
+
+CRLF = "\r\n"
+DELIMITER = ";"
+
+
+def _get_uva2_headers():
+    """Returns the headers required for the UVA2 files
+
+    :return:
+    """
+    publish_date = date.today().strftime("%Y%m%d")
+    return f"VAN;{publish_date}{CRLF}" \
+           f"TM;{publish_date}{CRLF}" \
+           f"HISTORISCHE_CYCLI;N{CRLF}"
+
+
+def uva2_exporter(api, file, format=None, append=False, filter: EntityFilter=None):
+    """UVA2 Exporter
+
+    Exports the output of the API to a ; delimited ASCII file with additional header rows
+
+    Format is a dictionary which can have the following attributes:
+
+    columns: A list of attributes which can be mapped 1-on-1 with the API output and csv column name
+
+        Example: ['identificatie', 'code', 'naam']
+
+    reference: Can be found in the _embedded block of the HAL JSON output. Reference will contain a
+               dictionary of API attributes with information on how to map them to csv columns.
+
+        Example:
+            ligtInBuurt: {
+                'ref': 'GBD.SDL',   -- The abbreviations for this catalog and collection
+                'ref_name': 'ligtIn',  -- A description of the relation used in the csv column name
+                'columns': ['identificatie', 'naam'],  -- The columns to be taken from this _embedded reference
+            }
+
+    mapping: A dictionary of mapings between API output and CSV columns. This is currently being used for the
+             state endpints as these aren't according to HAL JSON specs yet.
+
+        Example: 'ligtIn:GBD.SDL.identificatie': 'gebieden:stadsdelenIdentificatie',
+
+
+
+    :param filter:
+    :param api: the API wrapper which can be iterated through
+    :param file: the local file to write to
+    :param format: format definition, see above for examples
+    :param append:
+    :return:
+    """
+    row_count = 0
+
+    mapping = build_mapping_from_format(format)
+    fieldnames = [*mapping.keys()]
+
+    with open(file, 'a' if append else 'w', encoding='utf-8') as fp, \
+            ProgressTicker(f"Export entities", 10000) as progress:
+
+        # Write the headers
+        fp.write(_get_uva2_headers())
+
+        # Write the fieldnames
+        fp.write(f"{DELIMITER}".join(fieldnames))
+        fp.write(CRLF)
+
+        for entity in api:
+            if filter and not filter.filter(entity):
+                continue
+
+            row = f"{DELIMITER}".join([get_entity_value(entity, mapping[fieldname])
+                                       if get_entity_value(entity, mapping[fieldname]) else ''
+                                       for fieldname in fieldnames])
+            row += CRLF
+
+            fp.write(row)
+            row_count += 1
+            progress.tick()
+
+    return row_count

--- a/src/tests/exporter/config/test_uva2.py
+++ b/src/tests/exporter/config/test_uva2.py
@@ -1,0 +1,26 @@
+from unittest import TestCase
+from unittest.mock import patch, MagicMock
+from datetime import date
+
+from gobexport.exporter.config.uva2 import get_uva2_filename, format_uva2_date
+
+
+class TestUVA2ConfigHelpers(TestCase):
+
+    def test_get_uva2_filename(self):
+        publish_date = date.today().strftime('%Y%m%d')
+        self.assertEqual(f"UVA2_Actueel/ABC_{publish_date}_N_{publish_date}_{publish_date}.UVA2",
+                         get_uva2_filename('ABC'))
+
+        # Assert undefined file name raises error
+        with self.assertRaises(AssertionError):
+            get_uva2_filename(None)
+
+    def test_format_timestamp(self):
+        inp = '2035-03-31'
+        outp = '20350331'
+        self.assertEqual(outp, format_uva2_date(inp))
+
+        for inp in ['invalid_str', None]:
+            # These inputs should not change
+            self.assertEqual(inp, format_uva2_date(inp))

--- a/src/tests/exporter/test_utils.py
+++ b/src/tests/exporter/test_utils.py
@@ -212,16 +212,29 @@ class TestUtils(TestCase):
         entity = {}
 
         test_cases = [
-            ({'length': 5, 'value': 'a', 'character': '2'}, '2222a'),
-            ({'length': 5, 'value': 'ab', 'character': '0'}, '000ab'),
-            ({'length': 1, 'value': 'ab', 'character': '0'}, 'ab'),
+            ({'length': 5, 'value': 'a', 'character': '2', 'fill_type': 'rjust'}, '2222a'),
+            ({'length': 5, 'value': 'ab', 'character': '0', 'fill_type': 'rjust'}, '000ab'),
+            ({'length': 1, 'value': 'ab', 'character': '0', 'fill_type': 'rjust'}, 'ab'),
+        ]
+
+        for action, result in test_cases:
+            self.assertEqual(result, _evaluate_fill_action(entity, action))
+
+    @patch("gobexport.exporter.utils.get_entity_value", lambda entity, lookup_key: lookup_key)
+    def test_evaluate_fill_action_ljust(self):
+        entity = {}
+
+        test_cases = [
+            ({'length': 5, 'value': 'a', 'character': '2', 'fill_type': 'ljust'}, 'a2222'),
+            ({'length': 5, 'value': 'ab', 'character': '0', 'fill_type': 'ljust'}, 'ab000'),
+            ({'length': 1, 'value': 'ab', 'character': '0', 'fill_type': 'ljust'}, 'ab'),
         ]
 
         for action, result in test_cases:
             self.assertEqual(result, _evaluate_fill_action(entity, action))
 
     def test_evaluate_fill_action_missing_keys(self):
-        valid_action = {'length': '', 'value': '', 'character': ''}
+        valid_action = {'length': '', 'value': '', 'character': '', 'fill_type': ''}
 
         for key in valid_action.keys():
             action = valid_action.copy()
@@ -229,6 +242,12 @@ class TestUtils(TestCase):
 
             with self.assertRaises(AssertionError):
                 _evaluate_fill_action({}, action)
+
+    def test_evaluate_fill_action_invalid_fill_type(self):
+        invalid_action = {'length': '', 'value': '', 'character': '', 'fill_type': 'invalid'}
+
+        with self.assertRaises(AssertionError):
+            _evaluate_fill_action({}, invalid_action)
 
     @patch("gobexport.exporter.utils.get_entity_value")
     def test_evaluate_format_action(self, mock_get_entity_value):

--- a/src/tests/exporter/test_uva2.py
+++ b/src/tests/exporter/test_uva2.py
@@ -1,0 +1,38 @@
+from datetime import date
+
+from unittest import TestCase
+from unittest.mock import patch, MagicMock, mock_open, call
+
+from gobcore.exceptions import GOBException
+from gobexport.exporter.uva2 import _get_uva2_headers, CRLF, uva2_exporter
+
+
+class TestUVA2Exporter(TestCase):
+
+    def test_get_uva2_headers(self):
+        expected_result = f"VAN;20350101{CRLF}" \
+                          f"TM;20350101{CRLF}" \
+                          f"HISTORISCHE_CYCLI;N{CRLF}"
+
+        with patch('gobexport.exporter.uva2.date') as mock_date:
+            mock_date.today.return_value = date(2035, 1, 1)
+            self.assertEqual(expected_result, _get_uva2_headers())
+
+    @patch("gobexport.exporter.uva2.build_mapping_from_format")
+    @patch("builtins.open", mock_open())
+    @patch("gobexport.exporter.uva2.ProgressTicker")
+    def test_csv_exporter_filter(self, mock_progress_ticker, mock_build_mapping):
+        api = ['a']
+        file = ""
+
+        uva2_exporter(api, file)
+        mock_tick = mock_progress_ticker.return_value.__enter__.return_value
+        mock_tick.tick.assert_called_once()
+        mock_tick.tick.reset_mock()
+
+        mock_filter = MagicMock()
+        mock_filter.filter.return_value = False
+        uva2_exporter(api, file, filter=mock_filter)
+
+        mock_filter.filter.assert_called_with('a')
+        mock_tick.tick.assert_not_called()


### PR DESCRIPTION
UVA2 config is kept in a separate file and adds configs to the existing configs. This allows for easy removal when UVA2 files should not be exported anymore. The fill action was expanded to allow for ljust