### PR TITLE
GOB-1159 Add NUM UVA2 export

### DIFF
--- a/src/gobexport/exporter/config/uva2.py
+++ b/src/gobexport/exporter/config/uva2.py
@@ -8,16 +8,21 @@ from gobexport.filters.notempty_filter import NotEmptyFilter
 
 UVA2_DATE_FORMAT = '%Y%m%d'
 UVA2_STATUS_CODES = {
+    'nummeraanduidingen': {
+        '1': '16',
+        '2': '17',
+    },
     'openbareruimtes': {
         '1': '35',
         '2': '36',
-    }
+    },
 }
 
 
 def add_uva2_products():
     _add_woonplaatsen_uva2_config()
     _add_openbareruimtes_uva2_config()
+    _add_nummeraanduidingen_uva2_config()
 
 
 def format_uva2_date(datetimestr):
@@ -45,8 +50,11 @@ def format_uva2_status(value, entity_name=None):
 def get_uva2_filename(abbreviation):
     assert abbreviation, "UVA2 requires an abbreviation"
 
-    publish_date = date.today().strftime(UVA2_DATE_FORMAT)
-    return f"UVA2_Actueel/{abbreviation}_{publish_date}_N_{publish_date}_{publish_date}.UVA2"
+    def uva2_filename():
+        publish_date = date.today().strftime(UVA2_DATE_FORMAT)
+        return f"UVA2_Actueel/{abbreviation}_{publish_date}_N_{publish_date}_{publish_date}.UVA2"
+
+    return uva2_filename
 
 
 def _add_woonplaatsen_uva2_config():
@@ -76,7 +84,7 @@ def _add_woonplaatsen_uva2_config():
 """
 
     bag.WoonplaatsenExportConfig.products['uva2'] = {
-        'api_type': 'graphql',
+        'api_type': 'graphql_streaming',
         'exporter': uva2_exporter,
         'entity_filters': [
             NotEmptyFilter('amsterdamseSleutel'),
@@ -225,6 +233,109 @@ def _add_openbareruimtes_uva2_config():
             'OPRWPL/WPL/sleutelVerzendend': 'ligtInWoonplaats.[0].amsterdamseSleutel',
             'OPRWPL/WPL/Woonplaatsidentificatie': 'ligtInWoonplaats.[0].identificatie',
             'OPRWPL/TijdvakRelatie/begindatumRelatie': {
+                'action': 'format',
+                'formatter': format_uva2_date,
+                'value': 'beginGeldigheid',
+            },
+            'OPRWPL/TijdvakRelatie/einddatumRelatie': {
+                'action': 'format',
+                'formatter': format_uva2_date,
+                'value': 'eindGeldigheid',
+            }
+        },
+        'query': uva2_query
+    }
+
+
+def _add_nummeraanduidingen_uva2_config():
+    uva2_query = """
+{
+  bagNummeraanduidingen {
+    edges {
+      node {
+        amsterdamseSleutel
+        huisnummer
+        huisletter
+        huisnummertoevoeging
+        postcode
+        documentdatum
+        documentnummer
+        typeAdresseerbaarObject
+        beginGeldigheid
+        eindGeldigheid
+        status
+        ligtAanOpenbareruimte {
+          edges {
+            node {
+              amsterdamseSleutel
+              straatcode
+            }
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+    bag.NummeraanduidingenExportConfig.products['uva2'] = {
+        'api_type': 'graphql_streaming',
+        'exporter': uva2_exporter,
+        'entity_filters': [
+            NotEmptyFilter('amsterdamseSleutel'),
+        ],
+        'filename': get_uva2_filename("NUM"),
+        'mime_type': 'plain/text',
+        'format': {
+            'sleutelVerzendend': 'amsterdamseSleutel',
+            'IdentificatiecodeNummeraanduiding': 'amsterdamseSleutel',
+            'Huisnummer': 'huisnummer',
+            'Huisletter': 'huisletter',
+            'Huisnummertoevoeging': 'huisnummertoevoeging',
+            'Postcode': 'postcode',
+            'DocumentdatumMutatieNummeraanduiding': {
+                'action': 'format',
+                'formatter': format_uva2_date,
+                'value': 'documentdatum',
+            },
+            'DocumentnummerMutatieNummeraanduiding': 'documentnummer',
+            'TypeAdresseerbaarObjectDomein': 'typeAdresseerbaarObject.code',
+            'OmschrijvingTypeAdresseerbaarObjectDomein': 'typeAdresseerbaarObject.omschrijving',
+            'Adresnummer': '',
+            'Mutatie-gebruiker': '',
+            'Indicatie-vervallen': '',
+            'TijdvakGeldigheid/begindatumTijdvakGeldigheid': {
+                'action': 'format',
+                'formatter': format_uva2_date,
+                'value': 'beginGeldigheid',
+            },
+            'TijdvakGeldigheid/einddatumTijdvakGeldigheid': {
+                'action': 'format',
+                'formatter': format_uva2_date,
+                'value': 'eindGeldigheid',
+            },
+            'NUMBRN/BRN/Code': '',
+            'NUMBRN/TijdvakRelatie/begindatumRelatie': '',
+            'NUMBRN/TijdvakRelatie/einddatumRelatie': '',
+            'NUMSTS/STS/Code': {
+                'action': 'format',
+                'formatter': format_uva2_status,
+                'value': 'status.code',
+                'kwargs': {'entity_name': 'nummeraanduidingen'},
+            },
+            'NUMSTS/TijdvakRelatie/begindatumRelatie': {
+                'action': 'format',
+                'formatter': format_uva2_date,
+                'value': 'beginGeldigheid',
+            },
+            'NUMSTS/TijdvakRelatie/einddatumRelatie': {
+                'action': 'format',
+                'formatter': format_uva2_date,
+                'value': 'eindGeldigheid',
+            },
+            'NUMOPR/OPR/sleutelVerzendend': 'ligtAanOpenbareruimte.[0].amsterdamseSleutel',
+            'NUMOPR/WPL/Straatcode': 'ligtAanOpenbareruimte.[0].straatcode',
+            'NUMOPR/TijdvakRelatie/begindatumRelatie': {
                 'action': 'format',
                 'formatter': format_uva2_date,
                 'value': 'beginGeldigheid',

--- a/src/gobexport/exporter/uva2.py
+++ b/src/gobexport/exporter/uva2.py
@@ -76,7 +76,7 @@ def uva2_exporter(api, file, format=None, append=False, filter: EntityFilter=Non
             if filter and not filter.filter(entity):
                 continue
 
-            row = f"{DELIMITER}".join([get_entity_value(entity, mapping[fieldname])
+            row = f"{DELIMITER}".join([str(get_entity_value(entity, mapping[fieldname]))
                                        if get_entity_value(entity, mapping[fieldname]) else ''
                                        for fieldname in fieldnames])
             row += CRLF

--- a/src/tests/exporter/config/test_uva2.py
+++ b/src/tests/exporter/config/test_uva2.py
@@ -9,8 +9,10 @@ class TestUVA2ConfigHelpers(TestCase):
 
     def test_get_uva2_filename(self):
         publish_date = date.today().strftime('%Y%m%d')
-        self.assertEqual(f"UVA2_Actueel/ABC_{publish_date}_N_{publish_date}_{publish_date}.UVA2",
-                         get_uva2_filename('ABC'))
+
+        # Get uva2 filename return a callable
+        filename_function = get_uva2_filename('ABC')
+        self.assertEqual(f"UVA2_Actueel/ABC_{publish_date}_N_{publish_date}_{publish_date}.UVA2", filename_function())
 
         # Assert undefined file name raises error
         with self.assertRaises(AssertionError):
@@ -43,3 +45,17 @@ class TestUVA2ConfigHelpers(TestCase):
         for input in status:
             with self.assertRaises(AssertionError):
                 format_uva2_status(input, "openbareruimtes")
+
+    def test_format_uva2_status_nummeraanduidingen(self):
+        # Status 1 and 2 should be mapped to 16, 17 for nummeraanduidingen
+        status = [('1', '16'), ('2', '17'), (1, '16')]
+
+        for input, expected in status:
+            self.assertEqual(expected, format_uva2_status(input, "nummeraanduidingen"))
+
+        # Test invalid status for nummeraanduidingen
+        status = [3, '4', 'a', None]
+
+        for input in status:
+            with self.assertRaises(AssertionError):
+                format_uva2_status(input, "nummeraanduidingen")


### PR DESCRIPTION
Also fix a small bug with UVA2 filenames. The filename was being generated on boot of the module, so export dates could be wrong. The function returns a callable which is executed on export to ensure a valid date in the filename