### PR TITLE
[GOB-1215] Resolve filename on every export

### DIFF
--- a/src/gobexport/export.py
+++ b/src/gobexport/export.py
@@ -96,7 +96,8 @@ def _export_collection(host, catalogue, collection, product_name, destination):
         logger.info(f"Export to file '{name}' started, API type: {product.get('api_type', 'REST')}")
 
         # Get name of local file to write results to
-        results_file = _get_filename(product['filename']) if destination == "Objectstore" else product['filename']
+        results_file = _get_filename(product['resolved_filename']) if destination == "Objectstore" \
+            else product['resolved_filename']
 
         # Buffer items if they are used multiple times. This prevents calling API multiple times for same data
         source = product_source(product)
@@ -120,13 +121,13 @@ def _export_collection(host, catalogue, collection, product_name, destination):
                 # Do not add file to files again when appending
                 files.append({
                     'temp_location': results_file,
-                    'distribution': product['filename'],
+                    'distribution': product['resolved_filename'],
                     'mime_type': product['mime_type']})
 
             # Add extra result files (e.g. .prj file)
             extra_files = product.get('extra_files', [])
-            files.extend([{'temp_location': _get_filename(file['filename']),
-                           'distribution': file['filename'],
+            files.extend([{'temp_location': _get_filename(file['resolved_filename']),
+                           'distribution': file['resolved_filename'],
                            'mime_type': file['mime_type']} for file in extra_files])
 
     if destination == "Objectstore":

--- a/src/gobexport/test.py
+++ b/src/gobexport/test.py
@@ -89,7 +89,8 @@ def test(catalogue):
         resolve_config_filenames(config)
 
         for name, product in config.products.items():
-            filenames = [product['filename']] + [product['filename'] for product in product.get('extra_files', [])]
+            filenames = [product['resolved_filename']] + [product['resolved_filename']
+                                                          for product in product.get('extra_files', [])]
 
             for filename in filenames:
                 obj_info, obj = _get_file(conn_info, f"{catalogue}/{filename}")

--- a/src/gobexport/utils.py
+++ b/src/gobexport/utils.py
@@ -7,7 +7,7 @@ def resolve_config_filenames(config):
     """
 
     for product in config.products.values():
-        product['filename'] = product['filename']() if callable(product['filename']) else product['filename']
+        product['resolved_filename'] = product['filename']() if callable(product['filename']) else product['filename']
 
         for file in product.get('extra_files', []):
-            file['filename'] = file['filename']() if callable(file['filename']) else file['filename']
+            file['resolved_filename'] = file['filename']() if callable(file['filename']) else file['filename']

--- a/src/tests/test_utils.py
+++ b/src/tests/test_utils.py
@@ -26,11 +26,17 @@ class TestUtils(TestCase):
 
     def test_resolve_config_filenames(self):
         config = self.MockConfig()
+
+        # Expect resolved_filename to be added
         expected = {
             'product1': {
                 'filename': 'fname',
+                'resolved_filename': 'fname',
                 'extra_files': [
-                    {'filename': 'extra_file_name'}
+                    {
+                        'filename': 'extra_file_name',
+                        'resolved_filename': 'extra_file_name'
+                    }
                 ]
             }
         }
@@ -38,11 +44,16 @@ class TestUtils(TestCase):
 
         self.assertEqual(expected, config.products)
 
+        # Expect filename to still be the same function, and resolved filename to be added
         expected = {
             'product1': {
-                'filename': 'l_fname',
+                'filename': self.MockConfigFunctions.products['product1']['filename'],
+                'resolved_filename': 'l_fname',
                 'extra_files': [
-                    {'filename': 'l_extra_file_name'}
+                    {
+                        'filename': self.MockConfigFunctions.products['product1']['extra_files'][0]['filename'],
+                        'resolved_filename': 'l_extra_file_name'
+                    }
                 ]
             }
         }


### PR DESCRIPTION
Filenames were being resolved when an export was first called and the results saved in the config. When a container kept running the filename stayed as it was first resolved, resulting in an incorrect date in the filename. Now the filename is being resolved everytime and the original function isn’t being overwritten by the result of the resolve.