### PR TITLE
GOB-1289 Remove silently ignoring exception in export test file download

### DIFF
--- a/src/gobexport/test.py
+++ b/src/gobexport/test.py
@@ -129,14 +129,11 @@ def _get_file(conn_info, filename):
     :param filename: name of the file to retrieve
     :return:
     """
-    try:
-        for item in get_full_container_list(conn_info['connection'], conn_info['container']):
-            if item["name"] == filename:
-                obj_info = dict(item)
-                obj = get_object(conn_info['connection'], item, conn_info['container'])
-                return obj_info, obj
-    except Exception:
-        pass
+    for item in get_full_container_list(conn_info['connection'], conn_info['container']):
+        if item["name"] == filename:
+            obj_info = dict(item)
+            obj = get_object(conn_info['connection'], item, conn_info['container'])
+            return obj_info, obj
 
     return None, None
 

--- a/src/tests/test_test.py
+++ b/src/tests/test_test.py
@@ -328,22 +328,6 @@ class TestExportTest(TestCase):
         mock_get_object.assert_called_with('any connection', {'name': filename}, 'any container')
 
     @patch('gobexport.test.logger', MagicMock())
-    @patch('gobexport.test.get_object')
-    @patch('gobexport.test.get_full_container_list')
-    def test_get_file_exception(self, mock_get_full_container_list, mock_get_object):
-        conn_info = {
-            'connection': "any connection",
-            'container': "any container"
-        }
-        filename = "any filename"
-
-        mock_get_full_container_list.return_value = raise_exception
-        obj_info, obj = test._get_file(conn_info, filename)
-        self.assertIsNone(obj_info)
-        self.assertIsNone(obj)
-        mock_get_object.assert_not_called()
-
-    @patch('gobexport.test.logger', MagicMock())
     @patch('gobexport.test._get_file')
     @patch('gobexport.test._write_proposals')
     @patch('gobexport.test._get_checks')


### PR DESCRIPTION
According to git history, that try/except block was added to fix some tests earlier, by me. I really don't know why that was a good solution at the time, so I removed it again. Tests run fine without it.

Looks like the try/except block was sweeping something important under the rug. Let's see what's underneath it.