### PR TITLE
Disable GraphQL secure endpoints

### DIFF
--- a/src/gobexport/config.py
+++ b/src/gobexport/config.py
@@ -18,6 +18,10 @@ OIDC_TOKEN_ENDPOINT = os.getenv("OIDC_TOKEN_ENDPOINT")
 OIDC_CLIENT_ID = os.getenv("OIDC_CLIENT_ID")
 OIDC_CLIENT_SECRET = os.getenv("OIDC_CLIENT_SECRET")
 
+# Definition of URLs for public and secure endpoints
+PUBLIC_URL = '/gob'
+SECURE_URL = '/gob/secure'
+
 
 def get_host():
     """API Host

--- a/src/gobexport/exporter/__init__.py
+++ b/src/gobexport/exporter/__init__.py
@@ -91,12 +91,14 @@ def export_to_file(host, product, file, catalogue, collection, buffer_items=Fals
         query = product['query']
         expand_history = product.get('expand_history')
         sort = product.get('sort')
-        api = GraphQL(host, query, catalogue, collection, expand_history, sort=sort, unfold=unfold,
+        secure = product.get('secure', False)
+        api = GraphQL(host, query, catalogue, collection, expand_history, sort=sort, unfold=unfold, secure=secure,
                       row_formatter=product.get('row_formatter'),
                       cross_relations=product.get('cross_relations', False))
     elif product.get('api_type') == 'graphql_streaming':
         query = product['query']
-        api = GraphQLStreaming(host, query, unfold=unfold, sort=product.get('sort'),
+        secure = product.get('secure', False)
+        api = GraphQLStreaming(host, query, unfold=unfold, sort=product.get('sort'), secure=secure,
                                row_formatter=product.get('row_formatter'),
                                cross_relations=product.get('cross_relations', False),
                                batch_size=product.get('batch_size'))

--- a/src/gobexport/exporter/config/brk.py
+++ b/src/gobexport/exporter/config/brk.py
@@ -42,7 +42,7 @@ FILE_TYPE_MAPPING = {
 
 
 def _get_filename_date():
-    meta = requests.get(f"{get_host()}/gob/secure/brk/meta/1").json()
+    meta = requests.get(f"{get_host()}/gob/brk/meta/1").json()
     return dt_parser.parse(meta.get('kennisgevingsdatum'))
 
 
@@ -304,7 +304,7 @@ class KadastralesubjectenExportConfig:
 
     products = {
         'csv': {
-            'endpoint': '/gob/secure/brk/kadastralesubjecten/?view=enhanced&ndjson=true',
+            'endpoint': '/gob/brk/kadastralesubjecten/?view=enhanced&ndjson=true',
             'exporter': csv_exporter,
             'filename': lambda: brk_filename("kadastraal_subject"),
             'mime_type': 'plain/text',
@@ -2186,7 +2186,7 @@ class KadastraleGemeentecodesExportConfig:
         },
         'lineshape': {
             'exporter': esri_exporter,
-            'endpoint': '/gob/secure/brk/kadastralegemeentecodes/?view=linegeometry&ndjson=true',
+            'endpoint': '/gob/brk/kadastralegemeentecodes/?view=linegeometry&ndjson=true',
             'filename': f'{brk_directory("shp")}/{line_filename}.shp',
             'mime_type': 'application/octet-stream',
             'format': {
@@ -2279,7 +2279,7 @@ class KadastralesectiesExportConfig:
         },
         'lineshape': {
             'exporter': esri_exporter,
-            'endpoint': '/gob/secure/brk/kadastralesecties/?view=linegeometry&ndjson=true',
+            'endpoint': '/gob/brk/kadastralesecties/?view=linegeometry&ndjson=true',
             'filename': f'{brk_directory("shp")}/{line_filename}.shp',
             'mime_type': 'application/octet-stream',
             'format': {

--- a/src/gobexport/graphql.py
+++ b/src/gobexport/graphql.py
@@ -9,9 +9,11 @@ import time
 
 from gobcore.model import GOBModel
 
+from gobexport.config import PUBLIC_URL, SECURE_URL
 from gobexport.formatter.graphql import GraphQLResultFormatter
 
-GRAPHQL_ENDPOINT = '/gob/secure/graphql/'
+GRAPHQL_PUBLIC_ENDPOINT = f'{PUBLIC_URL}/graphql/'
+GRAPHQL_SECURE_ENDPOINT = f'{SECURE_URL}/graphql/'
 NUM_RECORDS = 1  # Initially ask for only one record
 TARGET_DURATION = 30  # Target request duration is 30 seconds
 
@@ -20,7 +22,7 @@ class GraphQL:
     sorter = None
 
     def __init__(self, host, query, catalogue, collection, expand_history=False, sort=None, unfold=False,
-                 row_formatter=None, cross_relations=False):
+                 row_formatter=None, cross_relations=False, secure=False):
         """Constructor
 
         Lazy loading, Just register host and query and wait for the iterator to be called
@@ -32,7 +34,7 @@ class GraphQL:
         :param collection:
         """
         self.host = host
-        self.url = self.host + GRAPHQL_ENDPOINT
+        self.url = self.host + (GRAPHQL_SECURE_ENDPOINT if secure else GRAPHQL_PUBLIC_ENDPOINT)
         self.catalogue = catalogue
         self.collection = collection
         self.schema_collection_name = f'{self.catalogue}{self.collection.title()}'

--- a/src/gobexport/graphql_streaming.py
+++ b/src/gobexport/graphql_streaming.py
@@ -3,17 +3,20 @@ import re
 
 from gobexport.requests import post_stream
 
+from gobexport.config import PUBLIC_URL, SECURE_URL
 from gobexport.formatter.graphql import GraphQLResultFormatter
 
-STREAMING_GRAPHQL_ENDPOINT = '/gob/secure/graphql/streaming/'
+STREAMING_GRAPHQL_PUBLIC_ENDPOINT = f'{PUBLIC_URL}/graphql/streaming/'
+STREAMING_GRAPHQL_SECURE_ENDPOINT = f'{SECURE_URL}/graphql/streaming/'
 
 
 class GraphQLStreaming:
 
     def __init__(self, host, query, unfold=False, sort=None, row_formatter=None, cross_relations=False,
-                 batch_size=None):
+                 batch_size=None, secure=False):
         self.host = host
         self.query = query
+        self.url = self.host + (STREAMING_GRAPHQL_SECURE_ENDPOINT if secure else STREAMING_GRAPHQL_PUBLIC_ENDPOINT)
         self.batch_size = batch_size
 
         self.formatter = GraphQLResultFormatter(sort=sort, unfold=unfold, row_formatter=row_formatter,
@@ -22,7 +25,7 @@ class GraphQLStreaming:
         self.current_page = None
 
     def _execute_query(self, query):
-        yield from post_stream(f"{self.host}{STREAMING_GRAPHQL_ENDPOINT}", {'query': query})
+        yield from post_stream(self.url, {'query': query})
 
     def _query_all(self):
         """Query on the input query as is. Don't add pagination.

--- a/src/gobexport/requests.py
+++ b/src/gobexport/requests.py
@@ -3,6 +3,7 @@ import time
 
 import urllib.request
 
+from gobexport.config import SECURE_URL
 from gobexport.keycloak import get_secure_header
 
 _MAX_TRIES = 60                # Maximum number of times to try the request
@@ -15,7 +16,7 @@ _RETRY_TIMEOUT = 60            # Seconds between consecetive retries
 _REQUEST_TIMEOUT = (60, 7200)  # Request timout to 60 seconds to connect and 2 hours for the data
 
 # String that identifies a secure GOB url. If an url contains this string it is the url of a secure endpoint
-_SECURE_URL = "/gob/secure/"
+_SECURE_URL = f'{SECURE_URL}/'
 
 
 class APIException(IOError):

--- a/src/tests/exporter/test_export.py
+++ b/src/tests/exporter/test_export.py
@@ -33,7 +33,7 @@ class MockAPI:
 
 class MockGraphQL:
     def __init__(self, host=None, query=None, catalogue=None, collection=None, expand_history=None, sort=None,
-                 unfold=False, row_formatter=None, cross_relations=False, batch_size=None):
+                 unfold=False, row_formatter=None, cross_relations=False, batch_size=None, secure=False):
         pass
 
     def __iter__(self):
@@ -160,13 +160,14 @@ class TestExportToFile(TestCase):
 
         product = {
             'api_type': 'graphql_streaming',
+            'secure': True,
             'query': 'some query',
             'exporter': MagicMock(),
             'format': 'the format',
         }
         result = export_to_file('host', product, 'file', 'catalogue', 'collection', False)
         mock_graphql_streaming.assert_called_with('host', product['query'], row_formatter=None, sort=None,
-                                                  unfold=False, cross_relations=False, batch_size=None)
+                                                  unfold=False, cross_relations=False, batch_size=None, secure=True)
 
         mock_buffered_iterable.assert_called_with(mock_graphql_streaming.return_value, 'source', buffer_items=False)
         product['exporter'].assert_called_with(mock_buffered_iterable.return_value, 'file', 'the format', append=False)
@@ -188,7 +189,7 @@ class TestExportToFile(TestCase):
         }
         result = export_to_file('host', product, 'file', 'catalogue', 'collection', False)
         mock_graphql_streaming.assert_called_with('host', product['query'], unfold='true_or_false', sort='sorter',
-                                                  row_formatter='row_form', cross_relations=False, batch_size=None)
+                                                  row_formatter='row_form', cross_relations=False, batch_size=None, secure=False)
 
     @patch("gobexport.exporter.GraphQLStreaming")
     @patch("gobexport.exporter.BufferedIterable")

--- a/src/tests/test_graphql.py
+++ b/src/tests/test_graphql.py
@@ -3,6 +3,7 @@ from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
 from gobexport.graphql import GraphQL
+from gobexport.graphql import GRAPHQL_PUBLIC_ENDPOINT, GRAPHQL_SECURE_ENDPOINT
 
 next = False
 
@@ -118,6 +119,13 @@ class TestGraphQl(TestCase):
 
         api = GraphQL('host', '{bagWoonplaatsen {edges {node { id}}}}', 'bag', 'woonplaatsen', sort=MagicMock())
         self.assertIsNotNone(api.formatter)
+
+    def test_secure(self):
+        api = GraphQL('host', '{bagWoonplaatsen {edges {node { id}}}}', 'bag', 'woonplaatsen')
+        self.assertEqual(api.url, f'host{GRAPHQL_PUBLIC_ENDPOINT}')
+
+        api = GraphQL('host', '{bagWoonplaatsen {edges {node { id}}}}', 'bag', 'woonplaatsen', secure=True)
+        self.assertEqual(api.url, f'host{GRAPHQL_SECURE_ENDPOINT}')
 
     @patch("gobexport.graphql.requests.post")
     @patch("gobexport.graphql.GraphQLResultFormatter")

--- a/src/tests/test_graphql_streaming.py
+++ b/src/tests/test_graphql_streaming.py
@@ -3,7 +3,8 @@ import random
 from unittest import TestCase
 from unittest.mock import patch, MagicMock
 
-from gobexport.graphql_streaming import GraphQLStreaming, STREAMING_GRAPHQL_ENDPOINT
+from gobexport.graphql_streaming import GraphQLStreaming
+from gobexport.graphql_streaming import STREAMING_GRAPHQL_PUBLIC_ENDPOINT, STREAMING_GRAPHQL_SECURE_ENDPOINT
 from typing import Generator
 
 
@@ -26,6 +27,13 @@ class TestGraphQLStreaming(TestCase):
 
         graphql_streaming._query_paginated.assert_called_once()
 
+    def test_secure(self, mock_formatter):
+        api = GraphQLStreaming('host', 'query')
+        self.assertEqual(api.url, f'host{STREAMING_GRAPHQL_PUBLIC_ENDPOINT}')
+
+        api = GraphQLStreaming('host', 'query', secure=True)
+        self.assertEqual(api.url, f'host{STREAMING_GRAPHQL_SECURE_ENDPOINT}')
+
     @patch("gobexport.graphql_streaming.post_stream")
     def test_execute_query(self, mock_post, mock_formatter):
         mock_post.return_value = iter(['a', 'b', 'c', 'd'])
@@ -34,7 +42,7 @@ class TestGraphQLStreaming(TestCase):
         result = graphql_streaming._execute_query('the query')
 
         self.assertEqual(['a', 'b', 'c', 'd'], list(result))
-        mock_post.assert_called_with(f'host{STREAMING_GRAPHQL_ENDPOINT}', {'query': 'the query'})
+        mock_post.assert_called_with(f'host{STREAMING_GRAPHQL_PUBLIC_ENDPOINT}', {'query': 'the query'})
 
     @patch("gobexport.graphql_streaming.json.loads", lambda x: x)
     def test_query_all(self, mock_formatter):


### PR DESCRIPTION
Secure endpoints can be used by specifying 'secure': True in the export definition
An example can be found in tests/exporter/test_export.py: test_export_to_file_graphql_streaming