### PR TITLE
[GOB-1349] Upgrade objectstore requirement

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -6,7 +6,7 @@ chardet==3.0.4
 Click==7.0
 coverage==4.5.1
 datapunt-config-loader==1.1.0
--e git+https://github.com/Amsterdam/objectstore.git@v1.0#egg=objectstore
+-e git+https://github.com/Amsterdam/objectstore.git@v1.0.1#egg=objectstore
 debtcollector==1.20.0
 flake8==3.5.0
 GDAL==2.1.3


### PR DESCRIPTION
This is to fix Export Test failures.