### PR TITLE
Fix bug with UniqueFilter

### DIFF
--- a/src/gobexport/exporter/__init__.py
+++ b/src/gobexport/exporter/__init__.py
@@ -132,9 +132,13 @@ def export_to_file(host, product, file, catalogue, collection, buffer_items=Fals
 
     kwargs = {}
 
-    if product.get('entity_filters'):
-        kwargs['filter'] = GroupFilter(product['entity_filters'])
+    filter = GroupFilter(product['entity_filters']) if product.get('entity_filters') else None
+    kwargs['filter'] = filter
 
     row_count = exporter(buffered_api, file, format, append=product.get('append', False), **kwargs)
+
+    # Reset the entity filter(s)
+    if filter:
+        filter.reset()
 
     return row_count

--- a/src/gobexport/filters/entity_filter.py
+++ b/src/gobexport/filters/entity_filter.py
@@ -3,3 +3,7 @@ class EntityFilter:
 
     def filter(self, entity: dict):
         raise NotImplementedError()
+
+    def reset(self):
+        # Some filters need a reset after exporting a file
+        pass

--- a/src/gobexport/filters/group_filter.py
+++ b/src/gobexport/filters/group_filter.py
@@ -18,3 +18,7 @@ class GroupFilter(EntityFilter):
         :return:
         """
         return all([f.filter(entity) for f in self.filters])
+
+    def reset(self):
+        for f in self.filters:
+            f.reset()

--- a/src/gobexport/filters/unique_filter.py
+++ b/src/gobexport/filters/unique_filter.py
@@ -19,3 +19,6 @@ class UniqueFilter(EntityFilter):
         else:
             self.values.add(value)
             return True
+
+    def reset(self):
+        self.values = set()

--- a/src/tests/exporter/test_export.py
+++ b/src/tests/exporter/test_export.py
@@ -191,7 +191,8 @@ class TestExportToFile(TestCase):
                                                   unfold=False, cross_relations=False, batch_size=None, secure=True)
 
         mock_buffered_iterable.assert_called_with(mock_graphql_streaming.return_value, 'source', buffer_items=False)
-        product['exporter'].assert_called_with(mock_buffered_iterable.return_value, 'file', 'the format', append=False)
+        product['exporter'].assert_called_with(mock_buffered_iterable.return_value, 'file', 'the format',
+                                               append=False, filter=None)
 
     @patch("gobexport.exporter.GraphQLStreaming")
     @patch("gobexport.exporter.BufferedIterable")
@@ -233,12 +234,17 @@ class TestExportToFile(TestCase):
         }
         result = export_to_file('host', product, 'file', 'catalogue', 'collection')
 
+        mock_filter = mock_group_filter.return_value
+
         mock_group_filter.assert_called_with([mock_entity_filter])
         mock_exporter.assert_called_with(mock_buffered_iterable.return_value,
                                          'file',
                                          'the format',
                                          append=False,
                                          filter=mock_group_filter.return_value)
+
+        # Assert the reset function is called on the filter
+        mock_filter.reset.assert_called()
 
     @patch("gobexport.exporter.ObjectstoreFile")
     @patch("gobexport.exporter.BufferedIterable")
@@ -256,4 +262,5 @@ class TestExportToFile(TestCase):
         mock_objectstore_file.assert_called_with(product['config'], row_formatter=None)
 
         mock_buffered_iterable.assert_called_with(mock_objectstore_file.return_value, 'source', buffer_items=False)
-        product['exporter'].assert_called_with(mock_buffered_iterable.return_value, 'file', 'the format', append=False)
+        product['exporter'].assert_called_with(mock_buffered_iterable.return_value, 'file', 'the format',
+                                               append=False, filter=None)

--- a/src/tests/filters/test_entity_filter.py
+++ b/src/tests/filters/test_entity_filter.py
@@ -9,3 +9,5 @@ class TestEntityFilter(TestCase):
 
         with self.assertRaises(NotImplementedError):
             entity_filter.filter({})
+
+        entity_filter.reset()

--- a/src/tests/filters/test_group_filter.py
+++ b/src/tests/filters/test_group_filter.py
@@ -8,9 +8,13 @@ class TestGroupFilter(TestCase):
     class MockEntityFilter:
         def __init__(self, value: bool):
             self.value = value
+            self.resetted = False
 
         def filter(self, entity: dict):
             return self.value
+        
+        def reset(self):
+            self.resetted = True
 
     def test_filter(self):
 
@@ -25,3 +29,7 @@ class TestGroupFilter(TestCase):
         for filters, result in test_cases:
             group_filter = GroupFilter(filters)
             self.assertEqual(result, group_filter.filter({}))
+            
+            group_filter.reset()
+            for filter in filters:
+                self.assertEqual(filter.resetted, True)

--- a/src/tests/filters/test_unique_filter.py
+++ b/src/tests/filters/test_unique_filter.py
@@ -24,3 +24,12 @@ class TestUniqueFilter(TestCase):
 
         for entity, result in test_cases:
             self.assertEqual(result, unique_filter.filter(entity))
+
+        # If the filter is called again, the results will be all False, because the set isn't cleared
+        for entity, result in test_cases:
+            self.assertEqual(False, unique_filter.filter(entity))
+
+        # Resetting the filter should return the original results
+        unique_filter.reset()
+        for entity, result in test_cases:
+            self.assertEqual(result, unique_filter.filter(entity))


### PR DESCRIPTION
Running the same export twice resulted in an empty export when a UniqueFilter was being used. The set used for checking uniqueness wasn’t cleared after an export is completed therefor the next run no records passed the UniqueFilter. A reset method was added which is run after all records are read from the API