### PR TITLE
Export tests use most recent file

### DIFF
--- a/src/gobexport/test.py
+++ b/src/gobexport/test.py
@@ -122,13 +122,23 @@ def _get_file(conn_info, filename):
     :param filename: name of the file to retrieve
     :return:
     """
+    # If the filename contains any replacement patterns, use the pattern to find the file
+    for src, dst in _REPLACEMENTS.items():
+        filename = re.sub(dst, src, filename)
+
+    obj_info = None
+    obj = None
     for item in get_full_container_list(conn_info['connection'], conn_info['container']):
-        if item["name"] == filename:
+        item_name = item['name']
+        for src, dst in _REPLACEMENTS.items():
+            item_name = re.sub(dst, src, item_name)
+
+        if item_name == filename and (obj_info is None or item['last_modified'] > obj_info['last_modified']):
+            # If multiple matches, match with the most recent item
             obj_info = dict(item)
             obj = get_object(conn_info['connection'], item, conn_info['container'])
-            return obj_info, obj
 
-    return None, None
+    return obj_info, obj
 
 
 def _get_check(checks, filename):

--- a/src/tests/test_test.py
+++ b/src/tests/test_test.py
@@ -327,6 +327,16 @@ class TestExportTest(TestCase):
         self.assertEqual(obj, "get object")
         mock_get_object.assert_called_with('any connection', {'name': filename}, 'any container')
 
+        filename = "20201201yz"
+        mock_get_full_container_list.return_value = iter([
+            {'name': '20201101yz', 'last_modified': '100'},
+            {'name': '20201103yz', 'last_modified': '300'},
+            {'name': '20201102yz', 'last_modified': '200'},
+        ])
+        mock_get_object.return_value = "get object"
+        obj_info, obj = test._get_file(conn_info, filename)
+        self.assertEqual(obj_info, {'name': '20201103yz', 'last_modified': '300'})
+
     @patch('gobexport.test.logger')
     @patch('gobexport.test._get_file')
     @patch('gobexport.test._write_proposals')


### PR DESCRIPTION
If date patterns occur in the filename then the most recent
file that matches the pattern is used to perform the export tests.