### PR TITLE
Do not start DUMP when no events have been added

### DIFF
--- a/src/gobexport/__main__.py
+++ b/src/gobexport/__main__.py
@@ -129,7 +129,8 @@ def dump_on_new_events(msg):
         'catalogue': notification.header.get('catalogue'),
         'collection': notification.header.get('collection'),
         'destination': 'Database',
-        'include_relations': False
+        'include_relations': False,
+        'wait_if_job_already_runs': True
     }
     start_workflow(workflow, arguments)
 

--- a/src/gobexport/__main__.py
+++ b/src/gobexport/__main__.py
@@ -116,6 +116,10 @@ def dump_on_new_events(msg):
     :return:
     """
     notification = get_notification(msg)
+    last_event_before, last_event_after = notification.contents['last_event']
+    if last_event_before == last_event_after:
+        # Nothing changed
+        return
 
     # Start an export cat-col to db workflow to update the analysis database
     workflow = {

--- a/src/tests/test_main.py
+++ b/src/tests/test_main.py
@@ -61,6 +61,9 @@ def test_main(mocked_messagedriven_service, mocked_dump, mocked_export, mocked_t
     }
 
     mock_notification = mock.MagicMock()
+    mock_notification.contents = {
+        'last_event': [1, 1]
+    }
     mock_get_notification.return_value = mock_notification
     mock_notification.header = header
 
@@ -72,5 +75,10 @@ def test_main(mocked_messagedriven_service, mocked_dump, mocked_export, mocked_t
         'destination': 'Database',
         'include_relations': False
     }
+    mock_start_workflow.assert_not_called()
+    mock_notification.contents = {
+        'last_event': [1, 2]
+    }
+    __main__.dump_on_new_events(msg)
     mock_start_workflow.assert_called_with({'workflow_name': 'export'}, expected_arguments)
 

--- a/src/tests/test_main.py
+++ b/src/tests/test_main.py
@@ -73,7 +73,8 @@ def test_main(mocked_messagedriven_service, mocked_dump, mocked_export, mocked_t
         'catalogue': 'any catalogue',
         'collection': 'any collection',
         'destination': 'Database',
-        'include_relations': False
+        'include_relations': False,
+        'wait_if_job_already_runs': True
     }
     mock_start_workflow.assert_not_called()
     mock_notification.contents = {


### PR DESCRIPTION
Prevent useless workflows