### PR TITLE
Onderzoek fixes

### DIFF
--- a/src/gobexport/exporter/config/bag.py
+++ b/src/gobexport/exporter/config/bag.py
@@ -3,6 +3,7 @@ from gobexport.exporter.esri import esri_exporter
 
 from gobexport.formatter.geometry import format_geometry
 
+import dateutil.parser as dt_parser
 
 """BAG export config
 
@@ -22,6 +23,8 @@ following properties:
                  well. For example the esri product creates .dbf, .shx and .prj
                  files.
 """
+
+TIMESTAMP_FORMAT = '%Y-%m-%dT%H:%M:%S'
 
 
 class BAGDefaultFormat:
@@ -53,6 +56,19 @@ class BAGDefaultFormat:
 
     def get_format(self):
         return self.format
+
+
+def format_date(datetimestr):
+    if not datetimestr:
+        # Input variable may be empty
+        return None
+
+    try:
+        dt = dt_parser.parse(datetimestr)
+        return dt.strftime(TIMESTAMP_FORMAT)
+    except ValueError:
+        # If invalid datetimestr, just return the original string so that no data is lost
+        return datetimestr
 
 
 class WoonplaatsenExportConfig:
@@ -1766,6 +1782,7 @@ class OnderzoekExportConfig:
         edges {
           node {
             objectIdentificatie
+            volgnummer
             objecttype
             kenmerk
             inOnderzoek
@@ -1782,16 +1799,62 @@ class OnderzoekExportConfig:
 '''
 
     format = {
-        'objectIdentificatie': 'objectIdentificatie',
+        'gerelateerdAan:BAG.identificatie': 'objectIdentificatie',
         'objecttype': 'objecttype',
         'kenmerk': 'kenmerk',
         'inOnderzoek': 'inOnderzoek',
         'documentnummer': 'documentnummer',
         'documentdatum': 'documentdatum',
-        'beginGeldigheid': 'beginGeldigheid',
-        'eindGeldigheid': 'eindGeldigheid',
-        'tijdstipRegistratie': 'tijdstipRegistratie',
-        'eindRegistratie': 'eindRegistratie',
+        'beginGeldigheid': {
+            'action': 'format',
+            'formatter': format_date,
+            'value': 'beginGeldigheid',
+        },
+        'eindGeldigheid': {
+            'action': 'format',
+            'formatter': format_date,
+            'value': 'eindGeldigheid',
+        },
+        'tijdstipRegistratie': {
+            'action': 'format',
+            'formatter': format_date,
+            'value': 'tijdstipRegistratie',
+        },
+        'eindRegistratie': {
+            'action': 'format',
+            'formatter': format_date,
+            'value': 'eindRegistratie',
+        },
+    }
+
+    history_format = {
+        'gerelateerdAan:BAG.identificatie': 'objectIdentificatie',
+        'volgnummer': 'volgnummer',
+        'objecttype': 'objecttype',
+        'kenmerk': 'kenmerk',
+        'inOnderzoek': 'inOnderzoek',
+        'documentnummer': 'documentnummer',
+        'documentdatum': 'documentdatum',
+        'beginGeldigheid': {
+            'action': 'format',
+            'formatter': format_date,
+            'value': 'beginGeldigheid',
+        },
+        'eindGeldigheid': {
+            'action': 'format',
+            'formatter': format_date,
+            'value': 'eindGeldigheid',
+        },
+        'tijdstipRegistratie': {
+            'action': 'format',
+            'formatter': format_date,
+            'value': 'tijdstipRegistratie',
+        },
+        'eindRegistratie': {
+            'action': 'format',
+            'formatter': format_date,
+            'value': 'eindRegistratie',
+        },
     }
 
     products = {
@@ -1809,6 +1872,6 @@ class OnderzoekExportConfig:
             'filename': 'CSV_Actueel/BAG_onderzoek_ActueelEnHistorie.csv',
             'mime_type': 'plain/text',
             'query': history_query,
-            'format': format
+            'format': history_format
         }
     }

--- a/src/gobexport/exporter/config/bag.py
+++ b/src/gobexport/exporter/config/bag.py
@@ -1869,7 +1869,7 @@ class OnderzoekExportConfig:
         'csv_history': {
             'exporter': csv_exporter,
             'api_type': 'graphql_streaming',
-            'filename': 'CSV_Actueel/BAG_onderzoek_ActueelEnHistorie.csv',
+            'filename': 'CSV_ActueelEnHistorie/BAG_onderzoek_ActueelEnHistorie.csv',
             'mime_type': 'plain/text',
             'query': history_query,
             'format': history_format

--- a/src/tests/exporter/config/test_bag.py
+++ b/src/tests/exporter/config/test_bag.py
@@ -1,0 +1,17 @@
+from unittest import TestCase
+from unittest.mock import patch, MagicMock
+
+from gobexport.exporter.config.bag import (
+    format_date,
+)
+
+
+def test_format_timestamp():
+    assert(format_date('2035-03-31') == '2035-03-31T00:00:00')
+    assert(format_date('') == None)
+
+    for dat in ['2035-03-31T10:30:30','2035-03-31T10:30:30.0000']:
+        assert(format_date(dat) == '2035-03-31T10:30:30')
+
+    for inp in [None, 'Invalid date']:
+        assert(format_date(inp) == inp)


### PR DESCRIPTION
Fixes for user stories PGB-997 and PGB-1008 (onderzoek_actueel and onderzoek_actueelenhistorie).
* Fixed timestamp format for actual and history file 
* Modified fieldname objectIdentificatie to gerelateerdAan:BAG.identificatie
* added volgnummer in history file
* Changed export location of history file