### PR TITLE
PGB-1281 Use clone of checks dict for each run to prevent side effects

### DIFF
--- a/src/gobexport/test.py
+++ b/src/gobexport/test.py
@@ -40,6 +40,7 @@ import hashlib
 import statistics
 import datetime
 import dateutil.parser
+import copy
 
 from objectstore.objectstore import get_full_container_list, get_object, put_object
 
@@ -110,7 +111,9 @@ def test(catalogue):
             for filename in filenames:
                 # Check the previously exported file at its temporary location
                 obj_info, obj = _get_file(conn_info, f"{EXPORT_DIR}/{catalogue}/{filename}")
-                check = _get_check(checks, filename)
+
+                # Clone check so that changes to the check file don't affect other runs
+                check = copy.deepcopy(_get_check(checks, filename))
 
                 # Report results with the name of the matched file
                 matched_filename = obj_info['name'] if obj_info else filename

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -9,7 +9,7 @@ datapunt-config-loader==1.1.0
 -e git+https://github.com/Amsterdam/objectstore.git@v1.0.1#egg=objectstore
 debtcollector==1.20.0
 flake8==3.5.0
-GDAL==2.1.3
+GDAL==2.4.4
 GeoAlchemy2==0.5.0
 geomet==0.2.0.post2
 -e git+https://github.com/Amsterdam/GOB-Core.git@v0.14.5.dataquality#egg=gobcore


### PR DESCRIPTION
The check dict is updated during a test run, which can make it invalid for subsequent runs. (For example, when updating unique_columns from column names to indices)

Use a clone of the check dict to avoid this.