### PR TITLE
Always start dump

### DIFF
--- a/src/gobexport/__main__.py
+++ b/src/gobexport/__main__.py
@@ -120,10 +120,6 @@ def dump_on_new_events(msg):
     :return:
     """
     notification = get_notification(msg)
-    last_event_before, last_event_after = notification.contents['last_event']
-    if last_event_before == last_event_after:
-        # Nothing changed
-        return
 
     # Start an export cat-col to db workflow to update the analysis database
     workflow = {
@@ -134,7 +130,7 @@ def dump_on_new_events(msg):
         'collection': notification.header.get('collection'),
         'destination': 'Database',
         'include_relations': False,
-        'wait_if_job_already_runs': True
+        'retry_time': 10 * 60   # retry for max 10 minutes if already running
     }
     start_workflow(workflow, arguments)
 

--- a/src/tests/test_main.py
+++ b/src/tests/test_main.py
@@ -83,9 +83,11 @@ class TestMain(TestCase):
             'collection': 'any collection',
             'destination': 'Database',
             'include_relations': False,
-            'wait_if_job_already_runs': True
+            'retry_time': mock.ANY
         }
-        mock_start_workflow.assert_not_called()
+        # workflow is also started if nothing has changed
+        mock_start_workflow.assert_called()
+        mock_start_workflow.reset_mock()
         mock_notification.contents = {
             'last_event': [1, 2]
         }


### PR DESCRIPTION
Dump is no longer smart, it just starts dump even when there
are no changes to be dumped.

Fix the retry trigger by using retry_time.