### PR TITLE
Limit IAM calls

### DIFF
--- a/src/gobexport/credential_store.py
+++ b/src/gobexport/credential_store.py
@@ -1,0 +1,81 @@
+import datetime
+
+
+class CredentialStore:
+
+    # Refresh or request new credentials when the credentials age is past the THRESHOLD of its validity
+    THRESHOLD = 0.75
+
+    def __init__(self, get_credentials, refresh_credentials):
+        """
+        Initialize the store
+
+        Use the get- and refresh credential methods to get new credentials or refresh existing credentials
+
+        :param get_credentials:
+        :param refresh_credentials:
+        """
+        self._credentials = None
+        self._timestamp = None
+        self._get_credentials = get_credentials
+        self._refresh_credentials = refresh_credentials
+
+    def _now(self):
+        """
+        Used to timestamp crecentials
+
+        :return:
+        """
+        return datetime.datetime.now()
+
+    def _age(self):
+        """
+        Age of credentials in seconds
+
+        :return:
+        """
+        return (self._now() - self._timestamp).total_seconds()
+
+    def get_credentials(self):
+        """
+        Get credentials
+
+        If the current credentials are still valid the return the current credentials
+        If the credentials can be refreshed then refresh the credentials and store these as the current credentials
+        Else request new credentials
+
+        :return:
+        """
+        if self._credentials:
+            # Get the age of the current credentials in seconds
+            age = self._age()
+            expires_in = self._credentials['expires_in']
+            refresh_expires_in = self._credentials['refresh_expires_in']
+            if age < expires_in * self.THRESHOLD:
+                # Credentials are still valid, no action required
+                pass
+            elif age < refresh_expires_in * self.THRESHOLD:
+                # Refresh credentials
+                credentials = self._refresh_credentials(self._credentials)
+                self._save_credentials(credentials)
+            else:
+                # Invalidate credentials
+                self._credentials = None
+                self._timestamp = None
+
+        if not self._credentials:
+            # (re)new token
+            credentials = self._get_credentials()
+            self._save_credentials(credentials)
+
+        return self._credentials
+
+    def _save_credentials(self, credentials):
+        """
+        Save the credentials as the current credentials
+
+        :param credentials:
+        :return:
+        """
+        self._credentials = credentials
+        self._timestamp = self._now()

--- a/src/gobexport/keycloak.py
+++ b/src/gobexport/keycloak.py
@@ -1,9 +1,24 @@
 import requests
 
 from gobexport.config import OIDC_TOKEN_ENDPOINT, OIDC_CLIENT_ID, OIDC_CLIENT_SECRET
+from gobexport.credential_store import CredentialStore
 
 _ACCESS_TOKEN = "access_token"
 _TOKEN_TYPE = "token_type"
+
+_credential_store = None
+
+
+def _init_credential_store():
+    """
+    Initialize the Credential Store
+
+    :return:
+    """
+    global _credential_store
+
+    if not _credential_store:
+        _credential_store = CredentialStore(get_credentials=get_credentials, refresh_credentials=refresh_credentials)
 
 
 def get_secure_header():
@@ -11,7 +26,8 @@ def get_secure_header():
     Get the request header to access secure endpoints
 
     """
-    credentials = get_credentials()
+    _init_credential_store()
+    credentials = _credential_store.get_credentials()
     return {
         'Authorization': f"{credentials[_TOKEN_TYPE]} {credentials[_ACCESS_TOKEN]}"
     }

--- a/src/tests/test_credential_store.py
+++ b/src/tests/test_credential_store.py
@@ -1,0 +1,87 @@
+from unittest import TestCase
+from unittest.mock import MagicMock
+
+import datetime
+
+from gobexport.credential_store import CredentialStore
+
+
+class TestCredentialStore(TestCase):
+
+    def test_init(self):
+        cs = CredentialStore('get', 'refresh')
+        self.assertEqual(cs._get_credentials, 'get')
+        self.assertEqual(cs._refresh_credentials, 'refresh')
+        self.assertIsNone(cs._credentials)
+
+    def test_save_credentials(self):
+        cs = CredentialStore('get', 'refresh')
+        self.assertIsNone(cs._credentials)
+        self.assertIsNone(cs._timestamp)
+
+        before = datetime.datetime.now()
+        cs._save_credentials('cred')
+        after = datetime.datetime.now()
+        self.assertEqual(cs._credentials, 'cred')
+        self.assertIsNotNone(cs._timestamp)
+        self.assertTrue(cs._timestamp >= before)
+        self.assertTrue(cs._timestamp <= after)
+
+    def test_get_credentials(self):
+        expires_in = 10
+        refresh_expires_in = 20
+        threshold = CredentialStore.THRESHOLD
+        access_threshold = int(expires_in * threshold)
+        refresh_threshold = int(refresh_expires_in * threshold)
+
+        get = MagicMock()
+        get.return_value = {
+            'token': 'access token',
+            'expires_in': expires_in,
+            'refresh_expires_in': refresh_expires_in
+        }
+        refresh = MagicMock()
+        refresh.return_value = {
+            'token': 'refreshed access token',
+            'expires_in': expires_in,
+            'refresh_expires_in': refresh_expires_in
+        }
+
+        cs = CredentialStore(get, refresh)
+
+        cs._now = MagicMock()
+        cs._now.return_value = datetime.datetime(2020, 1, 1, 12)
+
+        # Initial call => get credentials
+        cs.get_credentials()
+        get.assert_called_with()
+        refresh.assert_not_called()
+        self.assertEqual(cs._credentials, get.return_value)
+
+        get.reset_mock()
+
+        # Ask again => use stored credentials
+        cs.get_credentials()
+        get.assert_not_called()
+        refresh.assert_not_called()
+
+        # Ask again within access validity interval => use stored credentials
+        cs._now.return_value = cs._now.return_value + datetime.timedelta(seconds=access_threshold - 1)
+        cs.get_credentials()
+        get.assert_not_called()
+        refresh.assert_not_called()
+
+        # Ask again outside access validity interval => refresh credentials
+        cs._now.return_value = cs._now.return_value + datetime.timedelta(seconds=2)
+        cs.get_credentials()
+        get.assert_not_called()
+        refresh.assert_called()
+        self.assertEqual(cs._credentials, refresh.return_value)
+
+        refresh.reset_mock()
+
+        # Ask outside access and refresh validity interval => get new credentials
+        cs._now.return_value = cs._now.return_value + datetime.timedelta(seconds=refresh_threshold + 1)
+        cs.get_credentials()
+        get.assert_called()
+        refresh.assert_not_called()


### PR DESCRIPTION
Use token validities to determine if the token
can be reused, refreshed or re-initialized