### PR TITLE
Run notification handler in separate thread

### DIFF
--- a/src/gobexport/__main__.py
+++ b/src/gobexport/__main__.py
@@ -6,7 +6,7 @@ import datetime
 
 from gobcore.message_broker.config import WORKFLOW_EXCHANGE, EXPORT_QUEUE, EXPORT_TEST_QUEUE, EXPORT_RESULT_KEY, \
     EXPORT_TEST_RESULT_KEY
-from gobcore.message_broker.messagedriven_service import messagedriven_service
+from gobcore.message_broker.messagedriven_service import messagedriven_service, RUNS_IN_OWN_THREAD
 from gobcore.message_broker.notifications import listen_to_notifications, get_notification, DumpNotification, \
     ExportTestNotification, add_notification
 from gobcore.message_broker.config import EXPORT
@@ -156,7 +156,8 @@ SERVICEDEFINITION = {
     },
     'dump': {
         'queue': lambda: listen_to_notifications("dump", 'events'),
-        'handler': dump_on_new_events
+        'handler': dump_on_new_events,
+        RUNS_IN_OWN_THREAD: True
     }
 }
 

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -13,7 +13,7 @@ freezegun==0.3.15
 GDAL==2.4.4
 GeoAlchemy2==0.5.0
 geomet==0.2.0.post2
--e git+https://github.com/Amsterdam/GOB-Core.git@v0.16.9g#egg=gobcore
+-e git+https://github.com/Amsterdam/GOB-Core.git@v0.16.11b#egg=gobcore
 -e git+https://github.com/Amsterdam/GOB-Config.git@v0.4.11j#egg=gobconfig
 idna==2.7
 iso8601==0.1.12


### PR DESCRIPTION
Keep the notification queue as empty as possible
and have them converted in workflows as soon as possible