### PR TITLE
Alter GraphQL query for standplaatsen and ligplaatsen to use other relation to Woonplaatsen

### DIFF
--- a/src/gobexport/exporter/config/bag.py
+++ b/src/gobexport/exporter/config/bag.py
@@ -1325,19 +1325,19 @@ class LigplaatsenExportConfig:
                   node {
                     identificatie
                     naam
-                  }
-                }
-              }
-              ligtInWoonplaats {
-                edges {
-                  node {
-                    identificatie
-                    naam
-                    ligtInGemeente {
+                    ligtInWoonplaats {
                       edges {
                         node {
                           identificatie
                           naam
+                          ligtInGemeente {
+                            edges {
+                              node {
+                                identificatie
+                                naam
+                              }
+                            }
+                          }
                         }
                       }
                     }
@@ -1450,20 +1450,20 @@ class LigplaatsenExportConfig:
                     identificatie
                     volgnummer
                     naam
-                  }
-                }
-              }
-              ligtInWoonplaats(active: false) {
-                edges {
-                  node {
-                    identificatie
-                    volgnummer
-                    naam
-                    ligtInGemeente(active: false) {
+                    ligtInWoonplaats(active: false) {
                       edges {
                         node {
                           identificatie
+                          volgnummer
                           naam
+                          ligtInGemeente(active: false) {
+                            edges {
+                              node {
+                                identificatie
+                                naam
+                              }
+                            }
+                          }
                         }
                       }
                     }

--- a/src/gobexport/exporter/config/bag.py
+++ b/src/gobexport/exporter/config/bag.py
@@ -853,19 +853,19 @@ class StandplaatsenExportConfig:
                   node {
                     identificatie
                     naam
-                  }
-                }
-              }
-              ligtInWoonplaats {
-                edges {
-                  node {
-                    identificatie
-                    naam
-                    ligtInGemeente {
+                    ligtInWoonplaats {
                       edges {
                         node {
                           identificatie
                           naam
+                          ligtInGemeente {
+                            edges {
+                              node {
+                                identificatie
+                                naam
+                              }
+                            }
+                          }
                         }
                       }
                     }
@@ -978,20 +978,20 @@ class StandplaatsenExportConfig:
                     identificatie
                     volgnummer
                     naam
-                  }
-                }
-              }
-              ligtInWoonplaats(active: false) {
-                edges {
-                  node {
-                    identificatie
-                    volgnummer
-                    naam
-                    ligtInGemeente(active: false) {
+                    ligtInWoonplaats(active: false) {
                       edges {
                         node {
                           identificatie
+                          volgnummer
                           naam
+                          ligtInGemeente(active: false) {
+                            edges {
+                              node {
+                                identificatie
+                                naam
+                              }
+                            }
+                          }
                         }
                       }
                     }


### PR DESCRIPTION
The new import BAGExtract has less relations than we have with Neuron BAG.
Therefore I rewrote both BAG Ligplaatsen and BAG Standplaatsen GraphQL queries to use the 'default' BAG relations instead off the Amsterdam specific comfort relations.
With these commits all export products for standplaatsen and ligplaatsen should contain the correct data for Woonplaatsen and Gemeente.