### PR TITLE
11248: Show names of header columns in logs of uniqueness tests when provided

### DIFF
--- a/src/gobexport/test.py
+++ b/src/gobexport/test.py
@@ -469,33 +469,8 @@ def _check_csv(lines, obj_info, check):
     :param obj_info:
     :return:
     """
-    def replace_header_references(uniques: list, header: list):
-        """
-        Replaces column names in a uniques list with column indexes (1-based)
-
-        Example, with header A;B;C;D;E;F :
-            replace_header_references(['A', 'B', 'D']) => [1, 2, 4]
-            replace_header_references([1, 2, 5]) => [1, 2, 5]  # Leave as is
-
-        :param uniques:
-        :param header:
-        :return:
-        """
-        replaced = [header.index(col) + 1 if isinstance(col, str) else col for col in uniques]
-
-        if uniques != replaced:
-            logger.info(f"Interpreting columns {str(uniques)} as {str(replaced)}")
-
-        return replaced
 
     if obj_info['content_type'] in ["text/csv"] or obj_info['name'][-4:].lower() == ".csv":
-        # encode in utf-8 and decode as utf-8-sig to get rid of UTF-8 BOM
-        header = lines[0].encode('utf-8').decode('utf-8-sig').strip().split(';')
-
-        if check.get('unique_cols'):
-            # Replace column names with column indexes
-            check['unique_cols'] = [replace_header_references(uniques, header) for uniques in check['unique_cols']]
-
-        return CSVInspector(obj_info['name'], check).check_lines(lines)
+        return CSVInspector(obj_info['name'], lines[0], check).check_lines(lines)
     else:
         return {}

--- a/src/tests/test_csv_inspector.py
+++ b/src/tests/test_csv_inspector.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 from gobexport.csv_inspector import CSVInspector
 
@@ -7,24 +7,77 @@ from gobexport.csv_inspector import CSVInspector
 class TestCSVInspector(TestCase):
 
     def test_init(self):
-        i = CSVInspector('any filename', {})
+        i = CSVInspector('any filename', '', {})
         self.assertEqual(i.filename, 'any filename')
-        self.assertEqual(i.unique_cols, [])
+        self.assertEqual(i.unique_cols, {})
+
+    @patch("gobexport.csv_inspector.logger")
+    def test_init_set_unique_cols(self, mock_logger):
+        """
+        Tests that unique_cols is properly initialised when header names are provided
+        """
+        i = CSVInspector('any filename', 'a;b;c', {
+            'unique_cols': [['a', 'b'], ['c'], ['a', 'c']]
+        })
+        self.assertEqual({
+            "['a', 'b']": [1, 2],
+            "['c']": [3],
+            "['a', 'c']": [1, 3]
+        }, i.unique_cols)
+        mock_logger.info.assert_called_with("Checking any filename for unique column values in columns ['a', 'b'], ['c'], ['a', 'c']")
+
+    @patch("gobexport.csv_inspector.logger")
+    def test_init_set_unique_cols_decode_utf8_bom(self, mock_logger):
+        """
+        Tests that unique_cols works properly when UTF-8 BOM is present
+        """
+        headers = [
+            '\ufeffa;b;c\r\n',
+            '\ufeffa;b;c\r',
+            '\ufeffa;b;c\n',
+            '\ufeffa;b;c',
+        ]
+
+        for header in headers:
+            i = CSVInspector('any filename', header, {
+                'unique_cols': [['a', 'b'], ['c'], ['a', 'c']]
+            })
+            self.assertEqual({
+                "['a', 'b']": [1, 2],
+                "['c']": [3],
+                "['a', 'c']": [1, 3]
+            }, i.unique_cols)
+
+    @patch("gobexport.csv_inspector.logger")
+    def test_init_set_unique_cols_no_replacement(self, mock_logger):
+        """
+        Tests that unique_cols is properly initialised when column indexes are provided
+        """
+        i = CSVInspector('any filename', 'a;b;c', {
+            'unique_cols': [[1, 2], [3], [1, 3]]
+        })
+        self.assertEqual({
+            "[1, 2]": [1, 2],
+            "[3]": [3],
+            "[1, 3]": [1, 3]
+        }, i.unique_cols)
+        mock_logger.info.assert_called_with("Checking any filename for unique column values in columns [1, 2], [3], [1, 3]")
+
 
     @patch("gobexport.csv_inspector.logger")
     def test_log_intro(self, mock_logger):
-        i = CSVInspector('any filename', {})
-        i.unique_cols = []
+        i = CSVInspector('any filename', '', {})
+        i.unique_cols = {}
         i._log_intro()
         mock_logger.info.assert_not_called()
 
-        i.unique_cols = [[1]]
+        i.unique_cols = {'1': [1]}
         i._log_intro()
         mock_logger.info.assert_called()
 
     @patch("gobexport.csv_inspector.logger")
     def test_log_warning(self, mock_logger):
-        i = CSVInspector('any filename', {})
+        i = CSVInspector('any filename', '', {})
 
         i.warnings = 0
         i._log_warning("any key", "any value")
@@ -48,7 +101,7 @@ class TestCSVInspector(TestCase):
 
     @patch("gobexport.csv_inspector.logger", MagicMock())
     def test_check_uniqueness(self):
-        i = CSVInspector('any filename', {
+        i = CSVInspector('any filename', '', {
             'unique_cols': [[1], [2, 3]]
         })
         i._log_warning = MagicMock()
@@ -69,7 +122,7 @@ class TestCSVInspector(TestCase):
         self.assertEqual(i._log_warning.call_count, 2)
 
     def test_check_lengths(self):
-        i = CSVInspector('any filename', {})
+        i = CSVInspector('any filename', '', {})
         self.assertEqual(i.cols, {})
 
         i._check_lengths(['', 'a', 'bc'])
@@ -87,7 +140,7 @@ class TestCSVInspector(TestCase):
         })
 
     def test_check_columns(self):
-        i = CSVInspector('any filename', {})
+        i = CSVInspector('any filename', '', {})
         i._check_uniqueness = MagicMock()
         i._check_lengths = MagicMock()
         i.check_columns('any columns')
@@ -95,7 +148,7 @@ class TestCSVInspector(TestCase):
         i._check_lengths.assert_called_with('any columns')
 
     def test_check_lines(self):
-        i = CSVInspector('any filename', {})
+        i = CSVInspector('any filename', '', {})
         i.check_columns = MagicMock()
         lines = [
             'HEADERS',
@@ -104,3 +157,33 @@ class TestCSVInspector(TestCase):
 
         i.check_lines(lines)
         i.check_columns.assert_called_with(['A', 'B', 'C'])
+
+    @patch("gobexport.csv_inspector.logger")
+    def test_check_lines_unique(self, mock_logger):
+        lines = [
+            'a;b;c',
+            '1;2;3',
+            '1;3;4',
+            '1;2;2',
+            '2;3;3'
+        ]
+
+        i = CSVInspector('any filename', lines[0], {'unique_cols': [['a', 'b'], ['c']]})
+
+        res = i.check_lines(lines)
+
+        mock_logger.warning.assert_has_calls([
+            call("Non unique value found for ['a', 'b']: 1.2"),
+            call("Non unique value found for ['c']: 3"),
+        ])
+
+        self.assertEqual({
+            "['a', 'b']_is_unique": False,
+            "['c']_is_unique": False,
+            'minlength_col_1': 1,
+            'maxlength_col_1': 1,
+            'minlength_col_2': 1,
+            'maxlength_col_2': 1,
+            'minlength_col_3': 1,
+            'maxlength_col_3': 1
+        }, res)

--- a/src/tests/test_test.py
+++ b/src/tests/test_test.py
@@ -510,27 +510,19 @@ class TestExportTest(TestCase):
             'name': 'somefilename.csv',
             'content_type': 'text/csv',
         }
-        testcases = [
-            ('\ufeffA;B;C;D;E\r\n', [['A', 'C', 'E']], [[1, 3, 5]]),
-            ('\ufeffA;B;C;D;E\r', [['A', 'C', 'E']], [[1, 3, 5]]),
-            ('\ufeffA;B;C;D;E\n', [['A', 'C', 'E']], [[1, 3, 5]]),
-            ('A;B;C;D;E', [['A', 'C', 'E']], [[1, 3, 5]]),
-            ('\ufeffA;B;C;D;E\r\n', [[1, 3]], [[1, 3]]),
-            ('A;B;C;D;E', [[1, 3, 5]], [[1, 3, 5]]),
+
+        lines = [
+            'headerline',
+            'line1',
+            'lin2'
         ]
+        check = {'some': 'checks'}
+        res = test._check_csv(lines, obj_info, check)
+        self.assertEqual(mock_csv_inspector().check_lines(), res)
+        mock_csv_inspector.assert_any_call('somefilename.csv', 'headerline', check)
 
-        for first_line, unique_cols, expected_unique_cols in testcases:
-            lines = [
-                first_line,
-                'line1',
-                'line2',
-            ]
-            check = {
-                'unique_cols': unique_cols
-            }
-
-            res = test._check_csv(lines, obj_info, check)
-            self.assertEqual(mock_csv_inspector().check_lines(), res)
-            mock_csv_inspector.assert_any_call('somefilename.csv', {
-                'unique_cols': expected_unique_cols
-            })
+        obj_info = {
+            'name': 'someothertype.txt',
+            'content_type': 'text'
+        }
+        self.assertEqual({}, test._check_csv(lines, obj_info, check))


### PR DESCRIPTION
When 'unique_cols' is provided in checks file as a list of header names, we now show the header names in the export test logs instead of the column indices.

This PR consists of two commits: The first commit does not change any functionality, but merely makes the code easier to read. The second commit contains the functional changes.