### PR TITLE
Fix first bytes error

### DIFF
--- a/src/gobexport/test.py
+++ b/src/gobexport/test.py
@@ -35,6 +35,8 @@ unique_cols array of array of columns that should have unique values, e.g. [ [1]
 """
 import copy
 import datetime
+from pathlib import Path
+
 import dateutil.parser
 import hashlib
 import json
@@ -351,7 +353,7 @@ def _calculate_first_bytes(obj: bytes, obj_info: dict, n_bytes: int) -> str:
     Calculate md5 hash over the first n bytes.
     An offset can be defined in _FIRST_BYTES_OFFSET to allow skipping some initial bytes.
     """
-    file_type = obj_info['name'][-4:].lower()
+    file_type = Path(obj_info['name']).suffix.lower()
     offset = _FIRST_BYTES_OFFSET.get(file_type, 0)
     return hashlib.md5(obj[offset: n_bytes + offset]).hexdigest()
 
@@ -456,7 +458,7 @@ def _get_analysis(obj_info, obj, check=None):
     lowers = sum(c.islower() for c in content)
     uppers = sum(c.isupper() for c in content)
 
-    return_obj = {
+    return {
         **base_analysis,
         **lines_analysis,
         "first_lines": hashlib.md5(first_lines.encode(ENCODING)).hexdigest(),
@@ -473,7 +475,6 @@ def _get_analysis(obj_info, obj, check=None):
         "uppers": 0 if uppers == 0 else uppers / alphas,
         **cols
     }
-    return return_obj
 
 
 def _check_csv(lines, obj_info, check):

--- a/src/tests/test_test.py
+++ b/src/tests/test_test.py
@@ -51,6 +51,7 @@ class TestExportTest(TestCase):
         iso_now = datetime.datetime.now().isoformat()
         obj = b"1234567890"
         obj_info = {
+            "name": "any name",
             "last_modified": datetime.datetime.now().isoformat(),
             "bytes": len(obj),
             "content_type": "not plain/text"
@@ -148,6 +149,23 @@ class TestExportTest(TestCase):
         })
 
     @patch('gobexport.test.logger', MagicMock())
+    def test_get_analysis_dbf(self):
+        obj = b"a;b;c\n12;;1234\n1;123;1234\n"
+        obj_info = {
+            "name": "any name.dbf",
+            "last_modified": datetime.datetime.now().isoformat(),
+            "bytes": len(obj),
+            "content_type": 'application/octet-stream'
+        }
+        analysis = test._get_analysis(obj_info, obj)
+
+        self.assertEqual(analysis, {
+            'age_hours': mock.ANY,
+            'bytes': len(obj),
+            'first_bytes': '52770a7eaa1577f77e0616f97b751a5d'
+        })
+
+    @patch('gobexport.test.logger', MagicMock())
     def test_get_analysis_csv(self):
         iso_now = datetime.datetime.now().isoformat()
 
@@ -159,11 +177,11 @@ class TestExportTest(TestCase):
             "content_type": "text/csv"
         }
         analysis = test._get_analysis(obj_info, obj)
-        print(analysis)
+
         self.assertEqual(analysis, {
             'age_hours': mock.ANY,
             'bytes': len(obj),
-            'first_bytes': mock.ANY,
+            'first_bytes': 'ea0452cbcca052cf60dc3cc9a6fee193',
             'first_line': mock.ANY,
             'second_line': mock.ANY,
             'third_line': mock.ANY,


### PR DESCRIPTION
https://gdal.org/drivers/vector/shapefile.html#layer-creation-options
https://en.wikipedia.org/wiki/.dbf

dbf stores last update in byte 1-3. Skip these when checking for first_bytes equality