### PR TITLE
Fix dump for Amsterdam Schema relations

### DIFF
--- a/src/gobexport/app.py
+++ b/src/gobexport/app.py
@@ -32,7 +32,7 @@ def handle_export_dump_msg(msg):
     # DUMP is not a seperate workflow, it's just an export
     # Get the name for the logger, from the notification type
     with logger.configure_context(msg, DumpNotification.type.upper(), LOG_HANDLERS):
-        Dumper().dump_catalog(
+        Dumper().dump(
             catalog_name=header['catalogue'],
             collection_name=header['collection'],
             include_relations=header.get('include_relations', True),

--- a/src/tests/test_app.py
+++ b/src/tests/test_app.py
@@ -43,7 +43,7 @@ class TestApp(TestCase):
             collection="collection")
 
         mocked_export.reset_mock()
-        mocked_dump.return_value.dump_catalog.reset_mock()
+        mocked_dump.return_value.dump.reset_mock()
 
         msg['header']['destination'] = "Unkown destination"
         handle_export_msg(msg)
@@ -110,10 +110,10 @@ class TestApp(TestCase):
 
         mock_logger.configure_context.assert_called_with(msg, "DUMP", LOG_HANDLERS)
 
-        mock_dumper().dump_catalog.assert_called_with(catalog_name='CAT',
-                                                      collection_name='COLL',
-                                                      include_relations=True,
-                                                      force_full=False)
+        mock_dumper().dump.assert_called_with(catalog_name='CAT',
+                                              collection_name='COLL',
+                                              include_relations=True,
+                                              force_full=False)
 
         mock_add_notification.assert_called_with(msg, mock_dump_notification.return_value)
         mock_dump_notification.assert_called_with('CAT', 'COLL')
@@ -123,10 +123,10 @@ class TestApp(TestCase):
         msg['header']['include_relations'] = False
 
         handle_export_dump_msg(msg)
-        mock_dumper().dump_catalog.assert_called_with(catalog_name='CAT',
-                                                      collection_name='COLL',
-                                                      include_relations=False,
-                                                      force_full=True)
+        mock_dumper().dump.assert_called_with(catalog_name='CAT',
+                                              collection_name='COLL',
+                                              include_relations=False,
+                                              force_full=True)
 
     @mock.patch("gobexport.app.os._exit")
     @mock.patch("gobexport.app.messagedriven_service")


### PR DESCRIPTION
Change of relation names going from public to legacy schema caused the renamed relations to not be dumped. The new relation name could not be found in API.

Changed the dump logic in such a way that it does not fetch the collection from API, but just calls API with the new name. API handles translating the new names back to the legacy names.
Fetching the collection from API is still needed when dump is called with include_relations=True. Because we would not expect object tables to be renamed from legacy to public, this should never be a problem. However, to make sure this edge case will never go unnoticed anymore, a new error log is added as well in case the collection could not be found when we do need it.