### PR TITLE
BRK2 KOT exports (old).

### DIFF
--- a/src/gobexport/exporter/config/brk2/kadastraleobjecten.py
+++ b/src/gobexport/exporter/config/brk2/kadastraleobjecten.py
@@ -335,6 +335,44 @@ class KadastraleobjectenEsriNoSubjectsFormat(KadastraleobjectenCsvFormat):
         }
 
 
+class PerceelnummerEsriFormat:
+    def format_rotation(self, value):
+        """Return rotation with three decimal places."""
+        assert isinstance(value, (int, float))
+        return f"{value:.3f}"
+
+    def get_format(self):
+        """Kadastraleobjecten Perceelnummer ESRI format dictionary."""
+        return {
+            "BRK_KOT_ID": "identificatie",
+            "GEMEENTE": "aangeduidDoorGemeente.omschrijving",
+            "KADGEMCODE": "aangeduidDoorKadastralegemeentecode.omschrijving",
+            "KADGEM": "aangeduidDoorKadastralegemeente.omschrijving",
+            "SECTIE": "aangeduidDoorKadastralesectie",
+            "PERCEELNR": "perceelnummer",
+            "INDEXLTR": "indexletter",
+            "INDEXNR": "indexnummer",
+            "ROTATIE": {
+                "condition": "isempty",
+                "reference": "perceelnummerRotatie",
+                "falseval": {
+                    "action": "format",
+                    "formatter": self.format_rotation,
+                    "value": "perceelnummerRotatie",
+                },
+                "trueval": {
+                    "action": "literal",
+                    "value": "0.000",
+                },
+            },
+            "geometrie": {
+                "action": "format",
+                "formatter": format_geometry,
+                "value": "plaatscoordinaten",
+            },
+        }
+
+
 class KadastraleobjectenExportConfig:
     """Kadastraleobjecten export configuration."""
 
@@ -506,6 +544,28 @@ class KadastraleobjectenExportConfig:
 }
 """
 
+    perceelnummer_esri_format = PerceelnummerEsriFormat()
+    perceelnummer_query = """
+{
+  brk2Kadastraleobjecten(indexletter: "G") {
+    edges {
+      node {
+        identificatie
+        aangeduidDoorGemeente
+        aangeduidDoorKadastralegemeentecode
+        aangeduidDoorKadastralegemeente
+        aangeduidDoorKadastralesectie
+        perceelnummer
+        indexletter
+        indexnummer
+        perceelnummerRotatie
+        plaatscoordinaten
+      }
+    }
+  }
+}
+"""
+
     class VotFilter(EntityFilter):
         """Only include rows if vot identificatie is not set and city is not Amsterdam or Weesp."""
 
@@ -604,7 +664,7 @@ class KadastraleobjectenExportConfig:
             "mime_type": "application/octet-stream",
             "format": {
                 "BRK_KOT_ID": "identificatie",
-                "GEMEENTE": "aangeduidDoorGemeente.naam",
+                "GEMEENTE": "aangeduidDoorGemeente.omschrijving",
                 "KADGEMCODE": "aangeduidDoorKadastralegemeentecode.omschrijving",
                 "KADGEM": "aangeduidDoorKadastralegemeente.omschrijving",
                 "SECTIE": "aangeduidDoorKadastralesectie",
@@ -644,5 +704,43 @@ class KadastraleobjectenExportConfig:
                 },
             ],
             "query": bijpijling_query,
+        },
+        "perceel_shape": {
+            "exporter": esri_exporter,
+            "api_type": "graphql_streaming",
+            "secure_user": "gob",
+            "filename": f'{brk2_directory("shp", use_sensitive_dir=False)}/BRK_perceelnummer.shp',
+            "entity_filters": [
+                NotEmptyFilter("plaatscoordinaten"),
+            ],
+            "mime_type": "application/octet-stream",
+            "format": perceelnummer_esri_format.get_format(),
+            "extra_files": [
+                {
+                    "filename": (
+                        f'{brk2_directory("dbf", use_sensitive_dir=False)}/BRK_perceelnummer.dbf'
+                    ),
+                    "mime_type": "application/octet-stream",
+                },
+                {
+                    "filename": (
+                        f'{brk2_directory("shx", use_sensitive_dir=False)}/BRK_perceelnummer.shx'
+                    ),
+                    "mime_type": "application/octet-stream",
+                },
+                {
+                    "filename": (
+                        f'{brk2_directory("prj", use_sensitive_dir=False)}/BRK_perceelnummer.prj'
+                    ),
+                    "mime_type": "application/octet-stream",
+                },
+                {
+                    "filename": (
+                        f'{brk2_directory("cpg", use_sensitive_dir=False)}/BRK_perceelnummer.cpg'
+                    ),
+                    "mime_type": "application/octet-stream",
+                },
+            ],
+            "query": perceelnummer_query,
         },
     }

--- a/src/gobexport/exporter/config/brk2/kadastraleobjecten.py
+++ b/src/gobexport/exporter/config/brk2/kadastraleobjecten.py
@@ -486,6 +486,26 @@ class KadastraleobjectenExportConfig:
 }
 """
 
+    bijpijling_query = """
+{
+  brk2Kadastraleobjecten(indexletter:"G") {
+    edges {
+      node {
+        identificatie
+        aangeduidDoorGemeente
+        aangeduidDoorKadastralegemeentecode
+        aangeduidDoorKadastralegemeente
+        aangeduidDoorKadastralesectie
+        perceelnummer
+        indexletter
+        indexnummer
+        bijpijlingGeometrie
+      }
+    }
+  }
+}
+"""
+
     class VotFilter(EntityFilter):
         """Only include rows if vot identificatie is not set and city is not Amsterdam or Weesp."""
 
@@ -572,5 +592,57 @@ class KadastraleobjectenExportConfig:
                     "mime_type": "application/octet-stream",
                 },
             ],
+        },
+        "bijpijling_shape": {
+            "exporter": esri_exporter,
+            "api_type": "graphql_streaming",
+            "secure_user": "gob",
+            "filename": f'{brk2_directory("shp", use_sensitive_dir=False)}/BRK_bijpijling.shp',
+            "entity_filters": [
+                NotEmptyFilter("bijpijlingGeometrie"),
+            ],
+            "mime_type": "application/octet-stream",
+            "format": {
+                "BRK_KOT_ID": "identificatie",
+                "GEMEENTE": "aangeduidDoorGemeente.naam",
+                "KADGEMCODE": "aangeduidDoorKadastralegemeentecode.omschrijving",
+                "KADGEM": "aangeduidDoorKadastralegemeente.omschrijving",
+                "SECTIE": "aangeduidDoorKadastralesectie",
+                "PERCEELNR": "perceelnummer",
+                "INDEXLTR": "indexletter",
+                "INDEXNR": "indexnummer",
+                "geometrie": {
+                    "action": "format",
+                    "formatter": format_geometry,
+                    "value": "bijpijlingGeometrie",
+                },
+            },
+            "extra_files": [
+                {
+                    "filename": (
+                        f'{brk2_directory("dbf", use_sensitive_dir=False)}/BRK_bijpijling.dbf'
+                    ),
+                    "mime_type": "application/octet-stream",
+                },
+                {
+                    "filename": (
+                        f'{brk2_directory("shx", use_sensitive_dir=False)}/BRK_bijpijling.shx'
+                    ),
+                    "mime_type": "application/octet-stream",
+                },
+                {
+                    "filename": (
+                        f'{brk2_directory("prj", use_sensitive_dir=False)}/BRK_bijpijling.prj'
+                    ),
+                    "mime_type": "application/octet-stream",
+                },
+                {
+                    "filename": (
+                        f'{brk2_directory("cpg", use_sensitive_dir=False)}/BRK_bijpijling.cpg'
+                    ),
+                    "mime_type": "application/octet-stream",
+                },
+            ],
+            "query": bijpijling_query,
         },
     }

--- a/src/gobexport/exporter/config/brk2/kadastraleobjecten.py
+++ b/src/gobexport/exporter/config/brk2/kadastraleobjecten.py
@@ -3,11 +3,17 @@
 
 from fractions import Fraction
 
-from gobexport.exporter.config.brk2.utils import brk2_filename
+from gobexport.exporter.config.brk2.utils import (
+    brk2_filename,
+    brk2_directory,
+    format_timestamp,
+)
 from gobexport.exporter.csv import csv_exporter
-from gobexport.exporter.utils import get_entity_value
+from gobexport.exporter.esri import esri_exporter
+from gobexport.exporter.utils import get_entity_value, convert_format
 from gobexport.filters.entity_filter import EntityFilter
 from gobexport.filters.notempty_filter import NotEmptyFilter
+from gobexport.formatter.geometry import format_geometry
 
 
 class Brk2BagCsvFormat:
@@ -92,6 +98,242 @@ def aandeel_sort(a: dict, b: dict):
     return Fraction(a["teller"], a["noemer"]) > Fraction(b["teller"], b["noemer"])
 
 
+class KadastraleobjectenCsvFormat:
+    """CSV format class for KOT exports."""
+
+    def if_vve(self, trueval, falseval):
+        return {
+            "condition": "isempty",
+            "reference": "betrokkenBijAppartementsrechtsplitsingVve.[0].identificatie",
+            "negate": True,
+            "trueval": trueval,
+            "falseval": falseval,
+        }
+
+    def if_sjt(self, trueval, falseval=None):
+        val = {
+            "condition": "isempty",
+            "reference": "vanKadastraalsubject.[0].identificatie",
+            "negate": True,
+            "trueval": trueval,
+        }
+
+        if falseval:
+            val["falseval"] = falseval
+
+        return val
+
+    def if_empty_geen_waarde(self, reference):
+        return {
+            "condition": "isempty",
+            "reference": reference,
+            "negate": True,
+            "trueval": reference,
+            "falseval": {"action": "literal", "value": "geenWaarde"},
+        }
+
+    def comma_concatter(self, value):
+        return value.replace("|", ", ")
+
+    def concat_with_comma(self, reference):
+        """Replace occurrences of '|' in `reference` with commas."""
+        return {
+            "action": "format",
+            "value": reference,
+            "formatter": self.comma_concatter,
+        }
+
+    def format_kadgrootte(self, value):
+        floatval = float(value)
+
+        if floatval < 1:
+            return str(floatval)
+        return str(int(floatval))
+
+    def vve_or_subj(self, attribute):
+        return self.if_vve(
+            trueval=f"betrokkenBijAppartementsrechtsplitsingVve.[0].{attribute}",
+            falseval=f"vanKadastraalsubject.[0].{attribute}",
+        )
+
+    def get_format(self):
+        """Kadastraleobjecten CSV format dictionary."""
+        return {
+            "BRK_KOT_ID": "identificatie",
+            "KOT_GEMEENTENAAM": "aangeduidDoorGemeente.omschrijving",
+            "KOT_AKRKADGEMCODE_CODE": "aangeduidDoorKadastralegemeentecode.code",
+            "KOT_KADASTRALEGEMEENTE_CODE": "aangeduidDoorKadastralegemeentecode.omschrijving",
+            "KOT_KAD_GEMEENTECODE": "aangeduidDoorKadastralegemeente.code",
+            "KOT_KAD_GEMEENTE_OMS": "aangeduidDoorKadastralegemeente.omschrijving",
+            "KOT_SECTIE": "aangeduidDoorKadastralesectie",
+            "KOT_PERCEELNUMMER": "perceelnummer",
+            "KOT_INDEX_LETTER": "indexletter",
+            "KOT_INDEX_NUMMER": "indexnummer",
+            "KOT_SOORTGROOTTE_CODE": "soortGrootte.code",
+            "KOT_SOORTGROOTTE_OMS": "soortGrootte.omschrijving",
+            "KOT_KADGROOTTE": {
+                "action": "format",
+                "value": "grootte",
+                "formatter": self.format_kadgrootte,
+            },
+            "KOT_RELATIE_G_PERCEEL": "isOntstaanUitGPerceel.identificatie",
+            "KOT_KOOPSOM": "koopsom",
+            "KOT_KOOPSOM_VALUTA": "koopsomValutacode",
+            "KOT_KOOPJAAR": "koopjaar",
+            "KOT_INDICATIE_MEER_OBJECTEN": "indicatieMeerObjecten",
+            "KOT_CULTUURCODEONBEBOUWD_CODE": "soortCultuurOnbebouwd.code",
+            "KOT_CULTUURCODEONBEBOUWD_OMS": "soortCultuurOnbebouwd.omschrijving",
+            "KOT_CULTUURCODEBEBOUWD_CODE": self.if_empty_geen_waarde(
+                self.concat_with_comma("soortCultuurBebouwd.code")
+            ),
+            "KOT_CULTUURCODEBEBOUWD_OMS": self.if_empty_geen_waarde(
+                self.concat_with_comma("soortCultuurBebouwd.omschrijving")
+            ),
+            "KOT_AKRREGISTER9TEKST": "",
+            "KOT_STATUS_CODE": "status",
+            "KOT_TOESTANDSDATUM": {
+                "action": "format",
+                "formatter": format_timestamp,
+                "value": "toestandsdatum",
+            },
+            "KOT_IND_VOORLOPIGE_KADGRENS": {
+                "reference": "indicatieVoorlopigeKadastraleGrens",
+                "action": "case",
+                "values": {
+                    True: "Voorlopige grens",
+                    False: "Definitieve grens",
+                },
+            },
+            "BRK_SJT_ID": self.vve_or_subj("identificatie"),
+            "SJT_NAAM": self.if_vve(
+                trueval="betrokkenBijAppartementsrechtsplitsingVve.[0].statutaireNaam",
+                falseval=self.if_sjt(
+                    trueval={
+                        "condition": "isempty",
+                        "reference": "vanKadastraalsubject.[0].statutaireNaam",
+                        "trueval": {
+                            "action": "concat",
+                            "fields": [
+                                "vanKadastraalsubject.[0].geslachtsnaam",
+                                {"action": "literal", "value": ","},
+                                "vanKadastraalsubject.[0].voornamen",
+                                {"action": "literal", "value": ","},
+                                "vanKadastraalsubject.[0].voorvoegsels",
+                                {"action": "literal", "value": " ("},
+                                "vanKadastraalsubject.[0].geslacht.code",
+                                {"action": "literal", "value": ")"},
+                            ],
+                        },
+                        "falseval": "vanKadastraalsubject.[0].statutaireNaam",
+                    }
+                ),
+            ),
+            "SJT_TYPE": self.vve_or_subj("typeSubject"),
+            "SJT_NP_GEBOORTEDATUM": "vanKadastraalsubject.[0].geboortedatum",
+            "SJT_NP_GEBOORTEPLAATS": "vanKadastraalsubject.[0].geboorteplaats",
+            "SJT_NP_GEBOORTELAND_CODE": "vanKadastraalsubject.[0].geboorteland.code",
+            "SJT_NP_GEBOORTELAND_OMS": "vanKadastraalsubject.[0].geboorteland.omschrijving",
+            "SJT_NP_DATUMOVERLIJDEN": "vanKadastraalsubject.[0].datumOverlijden",
+            "SJT_NNP_RSIN": self.vve_or_subj("heeftRsinVoor.bronwaarde"),
+            "SJT_NNP_KVKNUMMER": self.vve_or_subj("heeftKvknummerVoor.bronwaarde"),
+            "SJT_NNP_RECHTSVORM_CODE": self.vve_or_subj("rechtsvorm.code"),
+            "SJT_NNP_RECHTSVORM_OMS": self.vve_or_subj("rechtsvorm.omschrijving"),
+            "SJT_NNP_STATUTAIRE_NAAM": self.vve_or_subj("statutaireNaam"),
+            "SJT_NNP_STATUTAIRE_ZETEL": self.vve_or_subj("statutaireZetel"),
+            "SJT_ZRT": "invRustOpKadastraalobjectBrkZakelijkerechten.[0].aardZakelijkRecht.omschrijving",
+            "SJT_AANDEEL": self.if_vve(
+                trueval={"action": "literal", "value": "1/1"},
+                falseval={
+                    "condition": "isempty",
+                    "reference": "invVanZakelijkrechtBrkTenaamstellingen.[0].aandeel.teller",
+                    "negate": True,
+                    "trueval": {
+                        "action": "concat",
+                        "fields": [
+                            "invVanZakelijkrechtBrkTenaamstellingen.[0].aandeel.teller",
+                            {
+                                "action": "literal",
+                                "value": "/",
+                            },
+                            "invVanZakelijkrechtBrkTenaamstellingen.[0].aandeel.noemer",
+                        ],
+                    },
+                    "falseval": {
+                        "action": "literal",
+                        "value": "ONBEKEND",
+                    },
+                },
+            ),
+            "SJT_VVE_SJT_ID": "betrokkenBijAppartementsrechtsplitsingVve.[0].identificatie",
+            "SJT_VVE_UIT_EIGENDOM": "betrokkenBijAppartementsrechtsplitsingVve.[0].statutaireNaam",
+            "KOT_INONDERZOEK": "inOnderzoek",
+            "KOT_MODIFICATION": "",
+            "GEOMETRIE": {
+                "action": "format",
+                "formatter": format_geometry,
+                "value": "geometrie",
+            },
+        }
+
+
+class KadastraleobjectenEsriNoSubjectsFormat(KadastraleobjectenCsvFormat):
+    """ESRI (GIS) format class for KOT exports without subjects."""
+
+    inonderzk = {
+        "condition": "isempty",
+        "reference": "inOnderzoek",
+        "trueval": {
+            "action": "literal",
+            "value": "N",
+        },
+        "falseval": {
+            "action": "literal",
+            "value": "J",
+        },
+    }
+
+    toestd_dat = {
+        "action": "format",
+        "formatter": format_timestamp,
+        "value": "toestandsdatum",
+        "kwargs": {"format": "%Y-%m-%d"},
+    }
+
+    def get_format(self):
+        """Kadastraleobjecten ESRI format dictionary."""
+        csv_format = super().get_format()
+        return convert_format(csv_format, self.get_mapping())
+
+    def get_mapping(self):
+        return {
+            "BRK_KOT_ID": "BRK_KOT_ID",
+            "GEMEENTE": "KOT_GEMEENTENAAM",
+            "KADGEMCODE": "KOT_KADASTRALEGEMEENTE_CODE",
+            "KADGEM": "KOT_KAD_GEMEENTE_OMS",
+            "SECTIE": "KOT_SECTIE",
+            "PERCEELNR": "KOT_PERCEELNUMMER",
+            "INDEXLTR": "KOT_INDEX_LETTER",
+            "INDEXNR": "KOT_INDEX_NUMMER",
+            "SOORTGCOD": "KOT_SOORTGROOTTE_CODE",
+            "SOORTGOMS": "KOT_SOORTGROOTTE_OMS",
+            "KADGROOTTE": "KOT_KADGROOTTE",
+            "REL_GPCL": "KOT_RELATIE_G_PERCEEL",
+            "KOOPSOM": "KOT_KOOPSOM",
+            "KOOPSOMVAL": "KOT_KOOPSOM_VALUTA",
+            "KOOPJAAR": "KOT_KOOPJAAR",
+            "MEEROB_IND": "KOT_INDICATIE_MEER_OBJECTEN",
+            "CULTONBCOD": "KOT_CULTUURCODEONBEBOUWD_CODE",
+            "CULTONBOMS": "KOT_CULTUURCODEONBEBOUWD_OMS",
+            "CULTBCOD": "KOT_CULTUURCODEBEBOUWD_CODE",
+            "CULTBOMS": "KOT_CULTUURCODEBEBOUWD_OMS",
+            "AKRREG9T": "KOT_AKRREGISTER9TEKST",
+            "STATUSCOD": "KOT_STATUS_CODE",
+            "TOESTD_DAT": self.toestd_dat,
+            "VL_KGR_IND": "KOT_IND_VOORLOPIGE_KADGRENS",
+            "INONDERZK": self.inonderzk,
+        }
+
+
 class KadastraleobjectenExportConfig:
     """Kadastraleobjecten export configuration."""
 
@@ -102,7 +344,6 @@ class KadastraleobjectenExportConfig:
     edges {
       node {
         identificatie
-        aangeduidDoorKadastralegemeente
         aangeduidDoorKadastralegemeentecode
         aangeduidDoorKadastralesectie
         perceelnummer
@@ -138,6 +379,100 @@ class KadastraleobjectenExportConfig:
                     huisletter
                     huisnummertoevoeging
                     postcode
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+    esri_format_no_subjects = KadastraleobjectenEsriNoSubjectsFormat()
+    esri_query = """
+{
+  brk2Kadastraleobjecten(indexletter:"G") {
+    edges {
+      node {
+        identificatie
+        volgnummer
+        aangeduidDoorGemeente
+        aangeduidDoorKadastralegemeentecode
+        aangeduidDoorKadastralegemeente
+        aangeduidDoorKadastralesectie
+        perceelnummer
+        indexletter
+        indexnummer
+        soortGrootte
+        grootte
+        isOntstaanUitGPerceel {
+          edges {
+            node {
+              identificatie
+            }
+          }
+        }
+        koopsom
+        koopsomValutacode
+        koopjaar
+        indicatieMeerObjecten
+        soortCultuurOnbebouwd
+        soortCultuurBebouwd
+        status
+        toestandsdatum
+        indicatieVoorlopigeKadastraleGrens
+        inOnderzoek
+        geometrie
+        invRustOpKadastraalobjectBrkZakelijkerechten(akrAardZakelijkRecht:"VE") {
+          edges {
+            node {
+              identificatie
+              aardZakelijkRecht
+              betrokkenBijAppartementsrechtsplitsingVve {
+                edges {
+                  node {
+                    identificatie
+                    statutaireNaam
+                    typeSubject
+                    heeftRsinVoor
+                    heeftKvknummerVoor
+                    heeftBsnVoor
+                    rechtsvorm
+                    statutaireNaam
+                    statutaireZetel
+                  }
+                }
+              }
+              invVanZakelijkrechtBrkTenaamstellingen {
+                edges {
+                  node {
+                    aandeel
+                    vanKadastraalsubject {
+                      edges {
+                        node {
+                          identificatie
+                          voornamen
+                          voorvoegsels
+                          geslachtsnaam
+                          geslacht
+                          statutaireNaam
+                          typeSubject
+                          geboortedatum
+                          geboorteplaats
+                          geboorteland
+                          datumOverlijden
+                          heeftRsinVoor
+                          heeftKvknummerVoor
+                          heeftBsnVoor
+                          rechtsvorm
+                          statutaireNaam
+                          statutaireZetel
+                        }
+                      }
+                    }
                   }
                 }
               }
@@ -194,5 +529,37 @@ class KadastraleobjectenExportConfig:
             "filename": lambda: brk2_filename("BRK_BAG", use_sensitive_dir=False),
             "mime_type": "text/csv",
             "format": brk2_bag_format.get_format(),
-        }
+        },
+        "kot_esri_actueel_no_subjects": {
+            "exporter": esri_exporter,
+            "api_type": "graphql_streaming",
+            "secure_user": "gob",
+            "query": esri_query,
+            "filename": f"{brk2_directory('shp', use_sensitive_dir=False)}"
+            "/BRK_Adam_totaal_G_zonderSubjecten.shp",
+            "mime_type": "application/octet-stream",
+            "format": esri_format_no_subjects.get_format(),
+            "extra_files": [
+                {
+                    "filename": f'{brk2_directory("dbf", use_sensitive_dir=False)}'
+                    "/BRK_Adam_totaal_G_zonderSubjecten.dbf",
+                    "mime_type": "application/octet-stream",
+                },
+                {
+                    "filename": f'{brk2_directory("shx", use_sensitive_dir=False)}'
+                    "/BRK_Adam_totaal_G_zonderSubjecten.shx",
+                    "mime_type": "application/octet-stream",
+                },
+                {
+                    "filename": f'{brk2_directory("prj", use_sensitive_dir=False)}'
+                    "/BRK_Adam_totaal_G_zonderSubjecten.prj",
+                    "mime_type": "application/octet-stream",
+                },
+                {
+                    "filename": f'{brk2_directory("cpg", use_sensitive_dir=False)}'
+                    "/BRK_Adam_totaal_G_zonderSubjecten.cpg",
+                    "mime_type": "application/octet-stream",
+                },
+            ],
+        },
     }

--- a/src/gobexport/exporter/config/brk2/kadastraleobjecten.py
+++ b/src/gobexport/exporter/config/brk2/kadastraleobjecten.py
@@ -305,6 +305,7 @@ class KadastraleobjectenEsriNoSubjectsFormat(KadastraleobjectenCsvFormat):
         return convert_format(csv_format, self.get_mapping())
 
     def get_mapping(self):
+        """Kadastraleobjecten ESRI without subjects mapping."""
         return {
             "BRK_KOT_ID": "BRK_KOT_ID",
             "GEMEENTE": "KOT_GEMEENTENAAM",
@@ -535,29 +536,39 @@ class KadastraleobjectenExportConfig:
             "api_type": "graphql_streaming",
             "secure_user": "gob",
             "query": esri_query,
-            "filename": f"{brk2_directory('shp', use_sensitive_dir=False)}"
-            "/BRK_Adam_totaal_G_zonderSubjecten.shp",
+            "filename": (
+                f"{brk2_directory('shp', use_sensitive_dir=False)}"
+                "/BRK_Adam_totaal_G_zonderSubjecten.shp"
+            ),
             "mime_type": "application/octet-stream",
             "format": esri_format_no_subjects.get_format(),
             "extra_files": [
                 {
-                    "filename": f'{brk2_directory("dbf", use_sensitive_dir=False)}'
-                    "/BRK_Adam_totaal_G_zonderSubjecten.dbf",
+                    "filename": (
+                        f'{brk2_directory("dbf", use_sensitive_dir=False)}'
+                        "/BRK_Adam_totaal_G_zonderSubjecten.dbf"
+                    ),
                     "mime_type": "application/octet-stream",
                 },
                 {
-                    "filename": f'{brk2_directory("shx", use_sensitive_dir=False)}'
-                    "/BRK_Adam_totaal_G_zonderSubjecten.shx",
+                    "filename": (
+                        f'{brk2_directory("shx", use_sensitive_dir=False)}'
+                        "/BRK_Adam_totaal_G_zonderSubjecten.shx"
+                    ),
                     "mime_type": "application/octet-stream",
                 },
                 {
-                    "filename": f'{brk2_directory("prj", use_sensitive_dir=False)}'
-                    "/BRK_Adam_totaal_G_zonderSubjecten.prj",
+                    "filename": (
+                        f'{brk2_directory("prj", use_sensitive_dir=False)}'
+                        "/BRK_Adam_totaal_G_zonderSubjecten.prj"
+                    ),
                     "mime_type": "application/octet-stream",
                 },
                 {
-                    "filename": f'{brk2_directory("cpg", use_sensitive_dir=False)}'
-                    "/BRK_Adam_totaal_G_zonderSubjecten.cpg",
+                    "filename": (
+                        f'{brk2_directory("cpg", use_sensitive_dir=False)}'
+                        "/BRK_Adam_totaal_G_zonderSubjecten.cpg"
+                    ),
                     "mime_type": "application/octet-stream",
                 },
             ],

--- a/src/gobexport/exporter/config/brk2/utils.py
+++ b/src/gobexport/exporter/config/brk2/utils.py
@@ -2,9 +2,11 @@
 
 
 from operator import itemgetter
+from typing import Optional
 
 import dateutil.parser as dt_parser
 import requests
+
 from gobexport.config import get_host
 from gobexport.utils import ttl_cache
 
@@ -78,3 +80,21 @@ def brk2_filename(name, file_type="csv", append_date=True, use_sensitive_dir=Tru
         datestr = f"_{date.strftime('%Y%m%d') if date else '00000000'}"
         return f"{brk2_directory(file_type,use_sensitive_dir)}/BRK_{name}{datestr}.{extension}"
     return f"{brk2_directory(file_type,use_sensitive_dir)}/BRK_{name}.{extension}"
+
+
+def format_timestamp(datetimestr: str, format: str = "%Y%m%d%H%M%S") -> Optional[str]:
+    """Transforms the datetimestr from ISO-format to the format used in the BRK2 exports: yyyymmddhhmmss
+
+    :param datetimestr:
+    :return:
+    """
+    if not datetimestr:
+        # Input variable may be empty.
+        return None
+
+    try:
+        dt = dt_parser.parse(datetimestr)
+        return dt.strftime(format)
+    except ValueError:
+        # If invalid datetimestr, just return the original string so that no data is lost.
+        return datetimestr

--- a/src/gobexport/exporter/shared/brk.py
+++ b/src/gobexport/exporter/shared/brk.py
@@ -1,0 +1,85 @@
+"""Shared BRK Format classes."""
+
+
+class SharedKadastraleobjectenCsvFormat:
+    """CSV format class for BRK Kadastraleobjecten exports."""
+
+    def if_vve(self, trueval, falseval):
+        return {
+            "condition": "isempty",
+            "reference": "betrokkenBijAppartementsrechtsplitsingVve.[0].identificatie",
+            "negate": True,
+            "trueval": trueval,
+            "falseval": falseval,
+        }
+
+    def if_sjt(self, trueval, falseval=None):
+        val = {
+            "condition": "isempty",
+            "reference": "vanKadastraalsubject.[0].identificatie",
+            "negate": True,
+            "trueval": trueval,
+        }
+
+        if falseval:
+            val["falseval"] = falseval
+
+        return val
+
+    def if_empty_geen_waarde(self, reference):
+        return {
+            "condition": "isempty",
+            "reference": reference,
+            "negate": True,
+            "trueval": reference,
+            "falseval": {"action": "literal", "value": "geenWaarde"},
+        }
+
+    def comma_concatter(self, value):
+        return value.replace("|", ", ")
+
+    def concat_with_comma(self, reference):
+        """Replace occurrences of '|' in `reference` with commas."""
+        return {
+            "action": "format",
+            "value": reference,
+            "formatter": self.comma_concatter,
+        }
+
+    def format_kadgrootte(self, value):
+        floatval = float(value)
+
+        if floatval < 1:
+            return str(floatval)
+        return str(int(floatval))
+
+    def vve_or_subj(self, attribute):
+        return self.if_vve(
+            trueval=f"betrokkenBijAppartementsrechtsplitsingVve.[0].{attribute}",
+            falseval=f"vanKadastraalsubject.[0].{attribute}",
+        )
+
+    def row_formatter(self, row):
+        """Merges all 'isOntstaanUitGPerceel' relations into one object.
+
+        With identificatie column concatenated into one, separated by comma's.
+
+        (Very) simplified example:
+        in     = { isOntstaanUitGPerceel: [{identificatie: 'A'}, {identificatie: 'B'}, {identificatie: 'C'}]}
+        result = { isOntstaanUitGPerceel: [{identificatie: 'A,B,C'}]}
+
+        :param row:
+        :return:
+        """
+        identificatie = ",".join(
+            [
+                edge["node"]["identificatie"]
+                for edge in row["node"]["isOntstaanUitGPerceel"].get("edges")
+            ]
+        )
+
+        row["node"]["isOntstaanUitGPerceel"] = {
+            "edges": [{"node": {"identificatie": identificatie}}]
+        }
+
+        return row

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -3,6 +3,5 @@ Flask-Cors==3.0.10
 pysftp==0.2.9
 freezegun==1.2.2
 requests-mock~=1.10.0
-python-keystoneclient~=5.0.1
--e git+https://github.com/Amsterdam/GOB-Core.git@v2.1.0#egg=gobcore
+-e git+https://github.com/Amsterdam/GOB-Core.git@v2.1.2#egg=gobcore
 -e git+https://github.com/Amsterdam/GOB-Config.git@v0.8.9#egg=gobconfig

--- a/src/tests/exporter/config/brk/test_kadastraleobjecten.py
+++ b/src/tests/exporter/config/brk/test_kadastraleobjecten.py
@@ -22,15 +22,6 @@ class TestKadastraleobjectenCsvFormat(TestCase):
         for inp, outp in testcases:
             self.assertEqual(outp, self.format.comma_concatter(inp))
 
-    def test_comma_no_space_concatter(self):
-        testcases = [
-            ('A|B', 'A,B'),
-            ('A', 'A'),
-        ]
-
-        for inp, outp in testcases:
-            self.assertEqual(outp, self.format.comma_no_space_concatter(inp))
-
     def test_concat_with_comma(self):
 
         self.assertEqual({
@@ -38,12 +29,6 @@ class TestKadastraleobjectenCsvFormat(TestCase):
             'value': 'the reference',
             'formatter': self.format.comma_concatter,
         }, self.format.concat_with_comma('the reference'))
-
-        self.assertEqual({
-            'action': 'format',
-            'value': 'the reference',
-            'formatter': self.format.comma_no_space_concatter,
-        }, self.format.concat_with_comma('the reference', False))
 
     def test_format_kadgrootte(self):
         testcases = [

--- a/src/tests/exporter/config/brk2/test_kadastraleobjecten.py
+++ b/src/tests/exporter/config/brk2/test_kadastraleobjecten.py
@@ -9,6 +9,8 @@ from gobexport.exporter.config.brk2.kadastraleobjecten import (
     Brk2BagCsvFormat,
     aandeel_sort,
     KadastraleobjectenExportConfig,
+    KadastraleobjectenCsvFormat,
+    KadastraleobjectenEsriNoSubjectsFormat,
 )
 
 
@@ -75,3 +77,94 @@ class TestBrk2ExportConfig(TestCase):
             vot_filter.filter(entity),
             "Should return True when VOT identification not set and city not set",
         )
+
+
+class TestKadastraleobjectenCsvFormat(TestCase):
+    """Kadastraleobjecten CSV format tests."""
+
+    def setUp(self) -> None:
+        self.format = KadastraleobjectenCsvFormat()
+
+    def test_comma_concatter(self):
+        testcases = [
+            ("A|B", "A, B"),
+            ("A", "A"),
+        ]
+
+        for inp, outp in testcases:
+            self.assertEqual(outp, self.format.comma_concatter(inp))
+
+    def test_concat_with_comma(self):
+        self.assertEqual(
+            {
+                "action": "format",
+                "value": "the reference",
+                "formatter": self.format.comma_concatter,
+            },
+            self.format.concat_with_comma("the reference"),
+        )
+
+    def test_format_kadgrootte(self):
+        testcases = [
+            ("1.0", "1"),
+            ("10.0", "10"),
+            ("0.1", "0.1"),
+            ("10", "10"),
+        ]
+
+        for inp, outp in testcases:
+            self.assertEqual(outp, self.format.format_kadgrootte(inp))
+
+    def test_if_vve(self):
+        expected = {
+            "condition": "isempty",
+            "reference": "betrokkenBijAppartementsrechtsplitsingVve.[0].identificatie",
+            "negate": True,
+            "trueval": {"true": "val"},
+            "falseval": "FALSEVAL",
+        }
+
+        self.assertEqual(expected, self.format.if_vve({"true": "val"}, "FALSEVAL"))
+
+    def test_if_sjt(self):
+        expected = {
+            "condition": "isempty",
+            "negate": True,
+            "reference": "vanKadastraalsubject.[0].identificatie",
+            "trueval": "the true val",
+        }
+
+        self.assertEqual(expected, self.format.if_sjt("the true val"))
+
+        expected["falseval"] = "the false val"
+
+        self.assertEqual(expected, self.format.if_sjt("the true val", "the false val"))
+
+    def test_vve_or_subj(self):
+        expected = {
+            "condition": "isempty",
+            "reference": "betrokkenBijAppartementsrechtsplitsingVve.[0].identificatie",
+            "negate": True,
+            "trueval": "betrokkenBijAppartementsrechtsplitsingVve.[0].theAttribute",
+            "falseval": "vanKadastraalsubject.[0].theAttribute",
+        }
+        self.assertEqual(expected, self.format.vve_or_subj("theAttribute"))
+
+
+class TestKadastraleobjectenEsriNoSubjectsFormat(TestCase):
+    """Kadastraleobjecten ESRI format test."""
+
+    def setUp(self) -> None:
+        self.format = KadastraleobjectenEsriNoSubjectsFormat()
+
+    @patch(
+        "gobexport.exporter.config.brk2.kadastraleobjecten.KadastraleobjectenCsvFormat.get_format",
+        Mock(return_value={"a": "A", "b": {"x": "X"}, "c": "C", "d": "D"}),
+    )
+    @patch(
+        "gobexport.exporter.config.brk2.kadastraleobjecten.KadastraleobjectenEsriNoSubjectsFormat.get_mapping",
+        Mock(return_value={"A": "a", "B": "b", "C": {"y": "Y"}}),
+    )
+    def test_get_format(self):
+        output = {"A": "A", "B": {"x": "X"}, "C": {"y": "Y"}}
+        self.assertEqual(self.format.get_format(), output)

--- a/src/tests/exporter/config/brk2/test_kadastraleobjecten.py
+++ b/src/tests/exporter/config/brk2/test_kadastraleobjecten.py
@@ -11,6 +11,7 @@ from gobexport.exporter.config.brk2.kadastraleobjecten import (
     KadastraleobjectenExportConfig,
     KadastraleobjectenCsvFormat,
     KadastraleobjectenEsriNoSubjectsFormat,
+    PerceelnummerEsriFormat,
 )
 
 
@@ -168,3 +169,26 @@ class TestKadastraleobjectenEsriNoSubjectsFormat(TestCase):
     def test_get_format(self):
         output = {"A": "A", "B": {"x": "X"}, "C": {"y": "Y"}}
         self.assertEqual(self.format.get_format(), output)
+
+
+class TestPerceelnummerEsriFormat(TestCase):
+    """Kadastraleobjecten Perceelnummer ESRI format test."""
+
+    def setUp(self) -> None:
+        self.format = PerceelnummerEsriFormat()
+
+    def test_format_rotation(self):
+        """Perceelnummer rotation test."""
+        testcases = [
+            (0, "0.000"),
+            (-0.234435345, "-0.234"),
+            (0.1299999999, "0.130"),
+        ]
+
+        for inp, outp in testcases:
+            self.assertEqual(self.format.format_rotation(inp), outp)
+
+        invalid_testcases = [None, ""]
+        for testcase in invalid_testcases:
+            with self.assertRaises(AssertionError):
+                self.format.format_rotation(testcase)

--- a/src/tests/exporter/config/brk2/test_kadastraleobjecten.py
+++ b/src/tests/exporter/config/brk2/test_kadastraleobjecten.py
@@ -151,6 +151,41 @@ class TestKadastraleobjectenCsvFormat(TestCase):
         }
         self.assertEqual(expected, self.format.vve_or_subj("theAttribute"))
 
+    def test_row_formatter(self):
+        row = {
+            "node": {
+                "isOntstaanUitGPerceel": {
+                    "edges": [
+                        {
+                            "node": {
+                                "identificatie": "percA",
+                            }
+                        },
+                        {
+                            "node": {
+                                "identificatie": "percB",
+                            }
+                        },
+                    ]
+                }
+            }
+        }
+        expected = {
+            "node": {
+                "isOntstaanUitGPerceel": {
+                    "edges": [
+                        {
+                            "node": {
+                                "identificatie": "percA,percB",
+                            }
+                        },
+                    ]
+                }
+            }
+        }
+
+        self.assertEqual(expected, self.format.row_formatter(row))
+
 
 class TestKadastraleobjectenEsriNoSubjectsFormat(TestCase):
     """Kadastraleobjecten ESRI format test."""

--- a/src/tests/exporter/config/brk2/test_utils.py
+++ b/src/tests/exporter/config/brk2/test_utils.py
@@ -10,6 +10,7 @@ from gobexport.exporter.config.brk2.utils import (
     _get_filename_date,
     brk2_directory,
     brk2_filename,
+    format_timestamp,
 )
 
 
@@ -84,3 +85,22 @@ class TestBrk2Utils(TestCase):
     def test_get_filename_date_404(self, mock_request_get):
         mock_request_get.return_value.status_code = 404
         self.assertIsNone(_get_filename_date())
+
+    def test_format_timestamp(self):
+        in_put = "2035-03-31T01:02:03.000000"
+        out_put = "20350331010203"
+        self.assertEqual(out_put, format_timestamp(in_put))
+
+        for in_put in ["invalid_str", None]:
+            # These inputs should not change
+            self.assertEqual(in_put, format_timestamp(in_put))
+
+    def test_format_timestamp_with_format(self):
+        in_put = "2035-03-31T01:02:03.000000"
+        date_format = "%Y-%m-%d"
+        out_put = "2035-03-31"
+        self.assertEqual(out_put, format_timestamp(in_put, format=date_format))
+
+        for in_put in ["invalid_str", None]:
+            # These inputs should not change
+            self.assertEqual(in_put, format_timestamp(in_put, format=format))


### PR DESCRIPTION
BRK2 KOT shape [exports](https://www.amsterdam.nl/stelselpedia/brk-index/producten-brk/prodspec-brk-shp/):

- `SHP_Actueel/BRK_Adam_totaal_G_zonderSubjecten.*` exports with BRK1 inverse relations
- `SHP_Actueel/BRK_bijpijling.*` exports
- `SHP_Actueel/BRK_perceelnummer.*` exports

Plus BRK2 KOT [`BRK_Kadastraal_object_<datum>.csv`](https://www.amsterdam.nl/stelselpedia/brk-index/producten-brk/productspecificatie-brk-subject/) export