### PR TITLE
Fix: split failed for lines containing quoted values, potentially wit…

### DIFF
--- a/src/tests/test_csv_inspector.py
+++ b/src/tests/test_csv_inspector.py
@@ -1,14 +1,13 @@
 from tempfile import TemporaryDirectory
 from unittest import TestCase
-from unittest.mock import MagicMock, call, patch
-from codecs import BOM_UTF8
+from unittest.mock import call, patch
 from gobexport.csv_inspector import CSVInspector
 
 
 class TestCSVInspector(TestCase):
 
     def test_init(self):
-        i = CSVInspector('any filename', b'', {}, 'tmp')
+        i = CSVInspector('any filename', [], {}, 'tmp')
         self.assertEqual(i.filename, 'any filename')
         self.assertEqual(i.unique_cols, {})
         self.assertEqual(i.tmp_dir, 'tmp')
@@ -18,7 +17,7 @@ class TestCSVInspector(TestCase):
         """
         Tests that unique_cols is properly initialised when header names are provided
         """
-        i = CSVInspector('any filename', b'a;b;c', {
+        i = CSVInspector('any filename', ["a", "b", "c"], {
             'unique_cols': [['a', 'b'], ['c'], ['a', 'c']]
         }, 'tmp')
         self.assertEqual({
@@ -30,26 +29,12 @@ class TestCSVInspector(TestCase):
         msg = "Checking any filename for unique column values in columns ['a','b'], ['c'], ['a','c']"
         mock_logger.info.assert_called_with(msg)
 
-    @patch("gobexport.csv_inspector.logger", MagicMock())
-    def test_init_set_unique_cols_decode_utf8_bom(self):
-        """
-        Tests that unique_cols works properly when UTF-8 BOM is present
-        """
-        i = CSVInspector('any filename', b'a;b;c', {
-            'unique_cols': [['a', 'b'], ['c'], ['a', 'c']]
-        }, 'tmp')
-        self.assertEqual({
-            "['a','b']": [1, 2],
-            "['c']": [3],
-            "['a','c']": [1, 3]
-        }, i.unique_cols)
-
     @patch("gobexport.csv_inspector.logger")
     def test_init_set_unique_cols_no_replacement(self, mock_logger):
         """
         Tests that unique_cols is properly initialised when column indexes are provided
         """
-        i = CSVInspector('any filename', b'a;b;c', {
+        i = CSVInspector('any filename', ["a", "b", "c"], {
             'unique_cols': [[1, 2], [3], [1, 3]]
         }, 'tmp')
         self.assertEqual({
@@ -61,7 +46,7 @@ class TestCSVInspector(TestCase):
 
     @patch("gobexport.csv_inspector.logger")
     def test_log_intro(self, mock_logger):
-        i = CSVInspector('any filename', b'', {}, 'tmp')
+        i = CSVInspector('any filename', [], {}, 'tmp')
         i.unique_cols = {}
         i._log_intro()
         mock_logger.info.assert_not_called()
@@ -71,24 +56,24 @@ class TestCSVInspector(TestCase):
         mock_logger.info.assert_called()
 
     @patch("gobexport.csv_inspector.logger")
-    def test_collect_values_for_uniquess_check(self, mock_logger):
-        i = CSVInspector('any filename', b'', {
+    def test_collect_values_for_uniquess_check(self, _):
+        i = CSVInspector('any filename', [], {
             'unique_cols': [[1], [2, 3]]
         }, 'tmp')
 
-        i._collect_values_for_uniquess_check([b'a', b'b', b'c'], 1)
+        i._collect_values_for_uniquess_check(['a', 'b', 'c'], 1)
 
-        self.assertEqual(i._write_cache["[1]"].getvalue(), b'1 a\n')
-        self.assertEqual(i._write_cache["[2,3]"].getvalue(), b'1 b.c\n')
+        self.assertEqual(i._write_cache["[1]"].getvalue(), '1 a\n')
+        self.assertEqual(i._write_cache["[2,3]"].getvalue(), '1 b.c\n')
 
     def test_check_lengths(self):
-        i = CSVInspector('any filename', b'', {}, 'tmp')
+        i = CSVInspector('any filename', [], {}, 'tmp')
         self.assertEqual(i.cols, {})
 
-        i._check_lengths([b'', b'a', b'bc'])
-        i._check_lengths([b'', b'ab', b'bc'])
-        i._check_lengths([b'', b'acdef', b'bc'])
-        i._check_lengths([b'', b'a', b'bc'])
+        i._check_lengths(['', 'a', 'bc'])
+        i._check_lengths(['', 'ab', 'bc'])
+        i._check_lengths(['', 'acdef', 'bc'])
+        i._check_lengths(['', 'a', 'bc'])
 
         self.assertEqual(i.cols, {
             'minlength_col_1': 0,
@@ -99,24 +84,15 @@ class TestCSVInspector(TestCase):
             'maxlength_col_3': 2
         })
 
-    def test_check_line(self):
-        i = CSVInspector('any filename', b'', {}, 'tmp')
-        i._collect_values_for_uniquess_check = MagicMock()
-        i._check_lengths = MagicMock()
-
-        i.check_line(b"A;B;C", 2)
-
-        i._collect_values_for_uniquess_check.assert_called_with([b'A', b'B', b'C'], 2)
-
     @patch("gobexport.csv_inspector.logger")
     def test_check_lines_unique(self, mock_logger):
         # [a,b] and [c] are non-unique, [d] is unique
         lines = [
-            b'a;b;c;d',
-            b'1;2;3;4',
-            b'1;3;4;5',
-            b'1;2;2;6',
-            b'2;3;3;7'
+            ['a', 'b', 'c', 'd'],
+            ["1", "2", "3", "4"],
+            ["1", "3", "4", "5"],
+            ["1", "2", "2", "6"],
+            ["2", "3", "3", "7"],
         ]
 
         with TemporaryDirectory() as tmp_dir:
@@ -149,15 +125,15 @@ class TestCSVInspector(TestCase):
     @patch("gobexport.csv_inspector.logger")
     def test_check_lines_unique_max_warnings(self, mock_logger):
         lines = [
-            b'a;b;c',
-            b'1;2;2',
-            b'2;3;4',
-            b'3;2;2',
-            b'4;3;3',
-            b'5;2;3',
-            b'6;3;4',
-            b'7;2;2',
-            b'8;3;3',
+            ["a", "b", "c"],
+            ["1", "2", "2"],
+            ["2", "3", "4"],
+            ["3", "2", "2"],
+            ["4", "3", "3"],
+            ["5", "2", "3"],
+            ["6", "3", "4"],
+            ["7", "2", "2"],
+            ["8", "3", "3"],
         ]
         with TemporaryDirectory() as tmp_dir:
             i = CSVInspector('any filename', lines[0], {'unique_cols': [['a'], ['c']]}, tmp_dir)


### PR DESCRIPTION
…… (#857)

Fix: use csvReader for parsing csv files

Quote chars were unhandled before. So we could end up with badly split lines when the line contained the delimiter halfway. Use CsvReader to parse all lines correctly.